### PR TITLE
Don't raise start attribute error on independent variables

### DIFF
--- a/src/XML/src/FMI2/fmi2_xml_variable.c
+++ b/src/XML/src/FMI2/fmi2_xml_variable.c
@@ -478,7 +478,7 @@ int fmi2_xml_handle_ScalarVariable(fmi2_xml_parser_context_t *context, const cha
 int fmi2_xml_get_has_start(fmi2_xml_parser_context_t *context, fmi2_xml_variable_t* variable) {
     int hasStart = fmi2_xml_is_attr_defined(context, fmi_attr_id_start);
     if(!hasStart)  {
-        if (variable->initial != (char)fmi2_initial_enu_calculated) {
+        if (variable->initial != (char)fmi2_initial_enu_calculated && variable->causality != fmi2_causality_enu_independent) {
             fmi2_xml_parse_error(context,
                     "Start attribute is required for this causality, variability and initial combination");
             hasStart = 1;


### PR DESCRIPTION
FMI 2 specification section 2.2.7 - causality: 
`If one variable is defined as "independent", it must be defined as "Real" without a "start" attribute.`

As explained in issue #21, the xml-parser should probably not give this error for "Real" "ScalarVariables" with causality=independent: 
_Start attribute is required for this causality, variability and initial combination_ 

Can it simply be fixed by checking the variables causality in `fmi2_xml_get_has_start` ?

Fixes modelon-community/fmi-library#21 