### PR TITLE
More ModelStructure verification

### DIFF
--- a/Config.cmake/test_fmi2.cmake
+++ b/Config.cmake/test_fmi2.cmake
@@ -42,6 +42,8 @@ set(XML_MF_PATH ${FMU2_DUMMY_FOLDER}/modelDescription_malformed.xml)
 
 set(VARIALBE_TEST_MODEL_DESC_DIR
     ${RTTESTDIR}/FMI2/parser_test_xmls/variable_test)
+set(FMI2_PARSER_TEST_XMLS_DIR
+    ${RTTESTDIR}/FMI2/parser_test_xmls)
 set(DEFAULT_EXPERIMENT_MODEL_DESC_DIR
     ${RTTESTDIR}/FMI2/parser_test_xmls/default_experiment/) # Trailing '/' necessary (for building system independent path)
 set(VARIABLE_NO_TYPE_MODEL_DESC_DIR
@@ -83,6 +85,8 @@ add_executable (fmi2_import_cs_test ${RTTESTDIR}/FMI2/fmi2_import_cs_test.c)
 target_link_libraries (fmi2_import_cs_test  ${FMILIBFORTEST})
 add_executable(fmi2_import_variable_test ${RTTESTDIR}/FMI2/fmi2_import_variable_test.c)
 target_link_libraries(fmi2_import_variable_test ${FMILIBFORTEST})
+add_executable(fmi2_import_model_structure_test ${RTTESTDIR}/FMI2/fmi2_import_model_structure_test.c)
+target_link_libraries(fmi2_import_model_structure_test ${FMILIBFORTEST})
 add_executable(fmi2_import_default_experiment_test ${RTTESTDIR}/FMI2/fmi2_import_default_experiment_test.c)
 target_link_libraries(fmi2_import_default_experiment_test ${FMILIBFORTEST})
 add_executable(fmi2_type_definitions_test ${RTTESTDIR}/FMI2/fmi2_import_type_definitions_test.c)
@@ -119,6 +123,9 @@ add_test(ctest_fmi2_import_test_cs fmi2_import_cs_test ${FMU2_CS_PATH} ${FMU_TEM
 add_test(ctest_fmi2_import_variable_test
          fmi2_import_variable_test
          ${VARIALBE_TEST_MODEL_DESC_DIR})
+add_test(ctest_fmi2_import_model_structure_test
+         fmi2_import_model_structure_test
+         ${FMI2_PARSER_TEST_XMLS_DIR})
 add_test(ctest_fmi2_import_default_experiment_test
          fmi2_import_default_experiment_test
          ${DEFAULT_EXPERIMENT_MODEL_DESC_DIR})
@@ -144,6 +151,7 @@ if(FMILIB_BUILD_BEFORE_TESTS)
         ctest_fmi2_import_test_me
         ctest_fmi2_import_test_cs
         ctest_fmi2_import_variable_test
+        ctest_fmi2_import_model_structure_test
         ctest_fmi2_import_default_experiment_test
         ctest_fmi2_variable_no_type_test
         ctest_fmi2_type_definitions_test

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,8 +1,18 @@
 # FMI Library Release Notes
 
-The release notes are typically a highlighting subset of all changes made. For full history, see resolved issues and commits.
+The release notes typically highlight a subset of all changes made. For full history, see resolved issues and commits.
 
 Note that version 2.1 is the first version with release notes. Please see the commit history for older versions.
+
+## 2.3
+
+- API:
+    - `fmi2_import_get_discrete_states_list`
+        - removed since `DiscreteState` element doesn't exist in FMI 2.0
+    - `fmi2_import_get_discrete_states_dependencies`
+        - removed since `DiscreteState` element doesn't exist in FMI 2.0
+- XML verification
+    - Added more checks for ModelStructure
 
 ## 2.2
 

--- a/Test/FMI2/fmi2_import_model_structure_test.c
+++ b/Test/FMI2/fmi2_import_model_structure_test.c
@@ -304,6 +304,14 @@ int main(int argc, char **argv)
     ret |= test_parse_xml(0, argv[1], "/model_structure/invalid/derivative_deps", log_ctx, NULL);
     free_ctx_log_once(&log_ctx);
 
+    /* Test that an error is raised when a ModelStructure.InitialUnknown list
+       has a dependency to an invalid variable.
+     */
+    log_ctx = create_ctx_log_once("Dependency for InitialUnknowns.Unknown incorrect. Expected input, output, or variable with "
+                                  "attribute initial='exact'. Dependency's index: '1'");
+    ret |= test_parse_xml(0, argv[1], "/model_structure/invalid/initunknown_deps", log_ctx, NULL);
+    free_ctx_log_once(&log_ctx);
+
 
     /* Test that a fatal error is raised when a dependency contains an index to a non-existing variable. */
 
@@ -311,7 +319,7 @@ int main(int argc, char **argv)
     log_ctx = create_ctx_log_once("XML element 'Unknown': listed index < 1: dependencies[0]=0");
     ret |= test_parse_xml(1, argv[1], "/model_structure/invalid/dependency_not_exist_lt1", log_ctx, NULL);
     free_ctx_log_once(&log_ctx);
-    /* index = -1*/
+    /* index = -1 */
     log_ctx = create_ctx_log_once("XML element 'Unknown': listed index < 1: dependencies[0]=-1");
     ret |= test_parse_xml(1, argv[1], "/model_structure/invalid/dependency_not_exist_lt2", log_ctx, NULL);
     free_ctx_log_once(&log_ctx);

--- a/Test/FMI2/fmi2_import_model_structure_test.c
+++ b/Test/FMI2/fmi2_import_model_structure_test.c
@@ -5,9 +5,39 @@
 #include "config_test.h"
 #include "fmil_test.h"
 
-/* Global set to 1 if logger cb found expected error message - must be reset
- * between tests. */
-static int g_logger_found_err_msg = 0;
+#define INVALID_TESTS_SILENT (1)
+
+#define CHECK_ALLOC(MEM_PTR) \
+    if (!MEM_PTR) { \
+        printf("Failed to alloc memory\n"); \
+        exit(1); /* No point in recovering since it's just a test */ \
+    }
+
+/*
+   General interface for checking log messages. It follows the same pattern as
+   "logger" and "componentEnvironment" in the FMI API.
+ */
+typedef void (*check_log_fcn)(void* context, const char* msg);
+typedef struct {
+    check_log_fcn check_fcn;     /* function that performs check */
+    void*         check_fcn_ctx; /* context for check_fcn */
+    int           silent;        /* does not print log to standard output */
+    int           success;       /* contains 1 if complete parsing check succeeded, else 0 */
+    const char*   err_msg;       /* error message to print on failure */
+} check_log_ctx;
+
+static void test_logger(jm_callbacks* cb, jm_string module, jm_log_level_enu_t log_level, jm_string message)
+{
+    /* Perform check */
+    check_log_ctx* log_ctx = (check_log_ctx*)cb->context;
+    log_ctx->check_fcn(log_ctx, message);
+
+    /* Print log to standard output */
+    if (!log_ctx->silent) {
+        jm_default_logger(cb, module, log_level, message);
+    }
+}
+
 
 /**
     TODO: function copied from PR 21; extract when merged
@@ -29,16 +59,15 @@ static char* concat(char* s1, char* s2)
 /**
     TODO: function copied from PR 21; extract when merged
 */
-static fmi2_import_t* parse_xml(const char* model_desc_path, jm_logger_f logger)
+static fmi2_import_t* parse_xml(const char* model_desc_path, check_log_ctx* chk_log_ctx)
 {
     jm_callbacks* cb = jm_get_default_callbacks();
     fmi_import_context_t* ctx = fmi_import_allocate_context(cb);
     fmi2_import_t* xml;
 
-    g_logger_found_err_msg = 0;
-
-    if (logger) {
-        cb->logger = logger;
+    if (chk_log_ctx) {
+        cb->logger = test_logger;
+        cb->context = chk_log_ctx;
     }
 
     if (ctx == NULL) {
@@ -51,20 +80,46 @@ static fmi2_import_t* parse_xml(const char* model_desc_path, jm_logger_f logger)
     return xml;
 }
 
+static void print_test_failure_summary(const char* err_msg, const char* xmlDir) {
+    printf("---\n");
+    printf("Test failed.\n");
+    printf("Error message: \n");
+    printf("  ");
+    printf("%s\n", err_msg);
+    printf("XML dir:\n");
+    printf("  ");
+    printf("%s\n", xmlDir);
+    printf("---\n");
+}
+
+
 /**
-    TODO: function copied from PR 21; extract when merged
+    TODO: function copied from PR 21; extract when merged (NOTE: Heavily
+    modified on this branch, use this version when merging)
 */
 /**
  * Tests that a unit referenced by a Type's attribute exists in UnitDefinitions.
  *
- * @xmlTestRootDir: path to 'parser_test_xmls' directory
- * @xmlDirRel: Relative path to the XML directory from root dir for parser test
- *   XMLs. Must start with leading '/' character.
- * @logger: logger function to use. If NULL, default logger will be used.
- * @xmlOut: return arg that will point to the parsed XML struct. Provide NULL
- *   if not desired.
+ * @expectFailure:
+ *    If the parsing is expected to fatally fail
+ *
+ * @xmlTestRootDir:
+ *    path to 'parser_test_xmls' directory
+ *
+ * @xmlDirRel:
+ *    Relative path to the XML directory from root dir for parser test
+ *    XMLs. Must start with leading '/' character.
+ *
+ * @chk_log_ctx:
+ *    logger context to use for checking the log. Success status is
+ *    cleared before parsing. If NULL, default logger will be used, and log
+ *    checking will be skipped.
+ *
+ * @xmlOut:
+ *    return arg that will point to the parsed XML struct. Provide NULL
+ *    if not desired. Must be freed if requested.
  */
-static int test_parse_xml(int expectFailure, char* xmlTestRootDir, char* xmlDirRel, jm_logger_f logger,
+static int test_parse_xml(int expectFailure, char* xmlTestRootDir, char* xmlDirRel, check_log_ctx* chk_log_ctx,
     fmi2_import_t** xmlOut)
 {
     char* xmlDir; /* path to the XML's parent directory */
@@ -73,20 +128,23 @@ static int test_parse_xml(int expectFailure, char* xmlTestRootDir, char* xmlDirR
 
     xmlDir = concat(xmlTestRootDir, xmlDirRel);
 
-    xml = parse_xml(xmlDir, logger);
+    if (chk_log_ctx) {
+        chk_log_ctx->success = 0;
+    }
+
+    xml = parse_xml(xmlDir, chk_log_ctx);
     if (xml != NULL && expectFailure) {
+        printf("Expected parsing to fail, but didn't. XML dir: '%s'", xmlDir);
         ret = CTEST_RETURN_FAIL;
         goto clean2;
     } else if (xml == NULL && !expectFailure) {
+        printf("Unexpectedly failed to parse XML. XML dir: '%s'", xmlDir);
         ret = CTEST_RETURN_FAIL;
         goto clean1;
     }
 
-    if (expectFailure && !g_logger_found_err_msg) {
-        printf("Logger unexpectedly did not find error message\n");
-        ret = CTEST_RETURN_FAIL;
-    } else if (!expectFailure && g_logger_found_err_msg) {
-        printf("Logger unexpectedly found error message\n");
+    if (chk_log_ctx && !chk_log_ctx->success) {
+        print_test_failure_summary(chk_log_ctx->err_msg, xmlDir);
         ret = CTEST_RETURN_FAIL;
     }
 
@@ -104,17 +162,44 @@ clean1:
     return ret;
 }
 
-/* Tests that an error is raised when a ModelStructure.Derivatives list
- * references a variable that doesn't have the attribute 'derivative'. */
-static void logger_invalid_state_derivative_reference(jm_callbacks* cb, jm_string module,
-        jm_log_level_enu_t log_level, jm_string message)
-{
-    char* expMsg = "The state derivative 'state_var' does not specify the state variable that it is a derivative of.";
-    if (!strncmp(expMsg, message, strlen(expMsg))) {
-        g_logger_found_err_msg = 1;
-    }
+typedef struct {
+    const char* expected_msg;
+} check_fcn_ctx_log_once;
 
-    jm_default_logger(cb, module, log_level, message);
+/* Checks that a message is logged once or more. */
+static void check_fcn_log_once(void* chk_log_ctx, const char* msg)
+{
+    check_log_ctx* log_ctx = (check_log_ctx*)chk_log_ctx;
+    check_fcn_ctx_log_once* fcn_ctx = (check_fcn_ctx_log_once*)log_ctx->check_fcn_ctx;
+
+    if (0 == strcmp(fcn_ctx->expected_msg, msg)) {
+        log_ctx->success = 1;
+    }
+}
+
+/* Returns a pointer to a check_log_ctx, or exits unsuccessfully on failure. */
+static check_log_ctx* create_log_once_ctx(const char* expected_msg) {
+    check_log_ctx* log_ctx = malloc(sizeof(check_log_ctx));
+    CHECK_ALLOC(log_ctx);
+
+    log_ctx->check_fcn = check_fcn_log_once;
+
+    log_ctx->check_fcn_ctx = malloc(sizeof(check_fcn_ctx_log_once));
+    CHECK_ALLOC(log_ctx->check_fcn_ctx);
+
+    ((check_fcn_ctx_log_once*)log_ctx->check_fcn_ctx)->expected_msg = expected_msg;
+
+    log_ctx->silent  = INVALID_TESTS_SILENT;
+    log_ctx->success = 0;
+    log_ctx->err_msg = "Failed to find expected error message in log.";
+
+    return log_ctx;
+}
+
+static void free_log_once_ctx(check_log_ctx** chk_log_ctx) {
+    free((*chk_log_ctx)->check_fcn_ctx);
+    free(*chk_log_ctx);
+    *chk_log_ctx = NULL;
 }
 
 static int test_modelstructure_valid(fmi2_import_t* xml)
@@ -128,22 +213,39 @@ static int test_modelstructure_valid(fmi2_import_t* xml)
 
 int main(int argc, char **argv)
 {
-    char* xml_dir      = NULL;
+    char* xml_dir = NULL;
     int ret = 0;
+    check_log_ctx* log_ctx;
 
     if (argc != 2) {
         printf("Usage: %s <path_to_'model_structure'_dir>\n", argv[0]);
         return CTEST_RETURN_FAIL;
     }
 
-    printf("Running fmi2_import_variable_test\n");
-
-    /* test valid */
+    /* ================ */
+    /* -- Test valid -- */
+    /* ================ */
     ret |= test_parse_xml(0, argv[1], "/model_structure/valid", NULL, NULL);
 
-    /* test invalid */
-    ret |= test_parse_xml(1, argv[1], "/model_structure/invalid/derivative_reference",
-            logger_invalid_state_derivative_reference, NULL);
+
+    /* ================== */
+    /* -- Test invalid -- */
+    /* ================== */
+
+    /* Tests that an error is raised when a ModelStructure.Derivatives list
+       references a variable that doesn't have the attribute 'derivative'.
+     */
+    log_ctx = create_log_once_ctx("The state derivative 'state_var' does not specify the state variable "
+                                  "that it is a derivative of.");
+    ret |= test_parse_xml(1, argv[1], "/model_structure/invalid/derivative_reference", log_ctx, NULL);
+    free_log_once_ctx(&log_ctx);
+
+    /* Tests that an error is raised when a ModelStructure.Outputs list
+       doesn't contain a reference to all variables with causality="output".
+     */
+    log_ctx = create_log_once_ctx("Output variable with index '1' not found in ModelStructure.Outputs");
+    ret |= test_parse_xml(0, argv[1], "/model_structure/invalid/outputs_missing", log_ctx, NULL);
+    free_log_once_ctx(&log_ctx);
 
     return ret;
 }

--- a/Test/FMI2/fmi2_import_model_structure_test.c
+++ b/Test/FMI2/fmi2_import_model_structure_test.c
@@ -243,8 +243,15 @@ int main(int argc, char **argv)
     /* Tests that an error is raised when a ModelStructure.Outputs list
        doesn't contain a reference to all variables with causality="output".
      */
-    log_ctx = create_log_once_ctx("Output variable with index '1' not found in ModelStructure.Outputs");
+    log_ctx = create_log_once_ctx("Output variable not found in ModelStructure.Outputs (index: 1, 0-based)");
     ret |= test_parse_xml(0, argv[1], "/model_structure/invalid/outputs_missing", log_ctx, NULL);
+    free_log_once_ctx(&log_ctx);
+
+    /* Tests that an error is raised when a ModelStructure.Outputs list
+       references a variable with causality!="output".
+     */
+    log_ctx = create_log_once_ctx("ModelStructure.Outputs listed a variable that doesn't have causality='output' (index: 0, 0-based)");
+    ret |= test_parse_xml(0, argv[1], "/model_structure/invalid/output_reference", log_ctx, NULL);
     free_log_once_ctx(&log_ctx);
 
     return ret;

--- a/Test/FMI2/fmi2_import_model_structure_test.c
+++ b/Test/FMI2/fmi2_import_model_structure_test.c
@@ -183,7 +183,7 @@ static void check_fcn_log_once(void* chk_log_ctx, const char* module, jm_log_lev
    Returns a pointer to a check_log_ctx, or exits program unsuccessfully on
    failure. Must be freed.
  */
-static check_log_ctx* create_log_once_ctx(const char* expected_msg) {
+static check_log_ctx* create_ctx_log_once(const char* expected_msg) {
     check_log_ctx* log_ctx = malloc(sizeof(check_log_ctx));
     CHECK_ALLOC(log_ctx);
 
@@ -201,7 +201,7 @@ static check_log_ctx* create_log_once_ctx(const char* expected_msg) {
     return log_ctx;
 }
 
-static void free_log_once_ctx(check_log_ctx** chk_log_ctx) {
+static void free_ctx_log_once(check_log_ctx** chk_log_ctx) {
     free((*chk_log_ctx)->check_fcn_ctx);
     free(*chk_log_ctx);
     *chk_log_ctx = NULL;
@@ -224,7 +224,7 @@ static void check_fcn_fail_on_warn_or_worse(void* chk_log_ctx, const char* modul
    messages. Program exist unsuccessfully on failure to return pointer. Pointer
    must be freed with respective free-method.
  */
-static check_log_ctx* create_fail_on_warn_or_worse_ctx() {
+static check_log_ctx* create_ctx_fail_on_warn_or_worse() {
     check_log_ctx* log_ctx = malloc(sizeof(check_log_ctx));
     CHECK_ALLOC(log_ctx);
 
@@ -237,7 +237,7 @@ static check_log_ctx* create_fail_on_warn_or_worse_ctx() {
     return log_ctx;
 }
 
-static void free_fail_on_warn_or_worse_ctx(check_log_ctx** chk_log_ctx) {
+static void free_ctx_fail_on_warn_or_worse(check_log_ctx** chk_log_ctx) {
     free(*chk_log_ctx);
     *chk_log_ctx = NULL;
 }
@@ -256,9 +256,9 @@ int main(int argc, char **argv)
     /* ================ */
     /* -- Test valid -- */
     /* ================ */
-    log_ctx = create_fail_on_warn_or_worse_ctx();
+    log_ctx = create_ctx_fail_on_warn_or_worse();
     ret |= test_parse_xml(0, argv[1], "/model_structure/valid", log_ctx, NULL);
-    free_fail_on_warn_or_worse_ctx(&log_ctx);
+    free_ctx_fail_on_warn_or_worse(&log_ctx);
 
 
     /* ================== */
@@ -268,57 +268,57 @@ int main(int argc, char **argv)
     /* Test that an error is raised when a ModelStructure.Derivatives list
        references a variable that doesn't have the attribute 'derivative'.
      */
-    log_ctx = create_log_once_ctx("The state derivative 'state_var' does not specify the state variable "
+    log_ctx = create_ctx_log_once("The state derivative 'state_var' does not specify the state variable "
                                   "that it is a derivative of.");
     ret |= test_parse_xml(1, argv[1], "/model_structure/invalid/derivative_reference", log_ctx, NULL);
-    free_log_once_ctx(&log_ctx);
+    free_ctx_log_once(&log_ctx);
 
     /* Test that an error is raised when a ModelStructure.Outputs list
        doesn't contain a reference to all variables with causality="output".
      */
-    log_ctx = create_log_once_ctx("Output variable not found in ModelStructure.Outputs (index: '2')");
+    log_ctx = create_ctx_log_once("Output variable not found in ModelStructure.Outputs (index: '2')");
     ret |= test_parse_xml(0, argv[1], "/model_structure/invalid/outputs_missing", log_ctx, NULL);
-    free_log_once_ctx(&log_ctx);
+    free_ctx_log_once(&log_ctx);
 
     /* Test that an error is raised when a ModelStructure.Outputs list
        references a variable with causality!="output".
      */
-    log_ctx = create_log_once_ctx("ModelStructure.Outputs listed a variable that doesn't have "
+    log_ctx = create_ctx_log_once("ModelStructure.Outputs listed a variable that doesn't have "
                                   "causality='output' (index: '1')");
     ret |= test_parse_xml(0, argv[1], "/model_structure/invalid/output_reference", log_ctx, NULL);
-    free_log_once_ctx(&log_ctx);
+    free_ctx_log_once(&log_ctx);
 
     /* Test that an error is raised when a ModelStructure.Outputs list
        has a dependency to an invalid variable.
      */
-    log_ctx = create_log_once_ctx("Dependency for Outputs.Unknown incorrect. Expected continuous state variable, "
+    log_ctx = create_ctx_log_once("Dependency for Outputs.Unknown incorrect. Expected continuous state variable, "
                                   "input or output. Dependency's index: '2'");
     ret |= test_parse_xml(0, argv[1], "/model_structure/invalid/output_deps", log_ctx, NULL);
-    free_log_once_ctx(&log_ctx);
+    free_ctx_log_once(&log_ctx);
 
     /* Test that an error is raised when a ModelStructure.Derivatives list
        has a dependency to an invalid variable.
      */
-    log_ctx = create_log_once_ctx("Dependency for Derivatives.Unknown incorrect. Expected continuous state variable, "
+    log_ctx = create_ctx_log_once("Dependency for Derivatives.Unknown incorrect. Expected continuous state variable, "
                                   "input or output. Dependency's index: '4'");
     ret |= test_parse_xml(0, argv[1], "/model_structure/invalid/derivative_deps", log_ctx, NULL);
-    free_log_once_ctx(&log_ctx);
+    free_ctx_log_once(&log_ctx);
 
 
     /* Test that a fatal error is raised when a dependency contains an index to a non-existing variable. */
 
     /* index = 0 */
-    log_ctx = create_log_once_ctx("XML element 'Unknown': listed index < 1: dependencies[0]=0");
+    log_ctx = create_ctx_log_once("XML element 'Unknown': listed index < 1: dependencies[0]=0");
     ret |= test_parse_xml(1, argv[1], "/model_structure/invalid/dependency_not_exist_lt1", log_ctx, NULL);
-    free_log_once_ctx(&log_ctx);
+    free_ctx_log_once(&log_ctx);
     /* index = -1*/
-    log_ctx = create_log_once_ctx("XML element 'Unknown': listed index < 1: dependencies[0]=-1");
+    log_ctx = create_ctx_log_once("XML element 'Unknown': listed index < 1: dependencies[0]=-1");
     ret |= test_parse_xml(1, argv[1], "/model_structure/invalid/dependency_not_exist_lt2", log_ctx, NULL);
-    free_log_once_ctx(&log_ctx);
+    free_ctx_log_once(&log_ctx);
     /* index > n_vars */
-    log_ctx = create_log_once_ctx("XML element 'Unknown': listed index > number of ScalarVariables (1): dependencies[0]=2");
+    log_ctx = create_ctx_log_once("XML element 'Unknown': listed index > number of ScalarVariables (1): dependencies[0]=2");
     ret |= test_parse_xml(1, argv[1], "/model_structure/invalid/dependency_not_exist_gt", log_ctx, NULL);
-    free_log_once_ctx(&log_ctx);
+    free_ctx_log_once(&log_ctx);
 
     return ret;
 }

--- a/Test/FMI2/fmi2_import_model_structure_test.c
+++ b/Test/FMI2/fmi2_import_model_structure_test.c
@@ -265,48 +265,36 @@ int main(int argc, char **argv)
     /* -- Test invalid -- */
     /* ================== */
 
-    /* Test that an error is raised when a ModelStructure.Derivatives list
-       references a variable that doesn't have the attribute 'derivative'.
-     */
+    /* 'Derivatives' dependency references a variable that doesn't have the attribute 'derivative'. */
     log_ctx = create_ctx_log_once("The state derivative 'state_var' does not specify the state variable "
                                   "that it is a derivative of.");
     ret |= test_parse_xml(1, argv[1], "/model_structure/invalid/derivative_reference", log_ctx, NULL);
     free_ctx_log_once(&log_ctx);
 
-    /* Test that an error is raised when a ModelStructure.Outputs list
-       doesn't contain a reference to all variables with causality="output".
-     */
+    /* 'Outputs' doesn't contain a reference to all variables with causality="output". */
     log_ctx = create_ctx_log_once("Output variable not found in ModelStructure.Outputs (index: '2')");
     ret |= test_parse_xml(0, argv[1], "/model_structure/invalid/outputs_missing", log_ctx, NULL);
     free_ctx_log_once(&log_ctx);
 
-    /* Test that an error is raised when a ModelStructure.Outputs list
-       references a variable with causality!="output".
-     */
+    /* 'Outputs' references a variable with causality!="output". */
     log_ctx = create_ctx_log_once("ModelStructure.Outputs listed a variable that doesn't have "
                                   "causality='output' (index: '1')");
     ret |= test_parse_xml(0, argv[1], "/model_structure/invalid/output_reference", log_ctx, NULL);
     free_ctx_log_once(&log_ctx);
 
-    /* Test that an error is raised when a ModelStructure.Outputs list
-       has a dependency to an invalid variable.
-     */
+    /* 'Outputs' has a dependency on an invalid variable. */
     log_ctx = create_ctx_log_once("Dependency for Outputs.Unknown incorrect. Expected continuous state variable, "
                                   "input or output. Dependency's index: '2'");
     ret |= test_parse_xml(0, argv[1], "/model_structure/invalid/output_deps", log_ctx, NULL);
     free_ctx_log_once(&log_ctx);
 
-    /* Test that an error is raised when a ModelStructure.Derivatives list
-       has a dependency to an invalid variable.
-     */
+    /* 'Derivatives' has a dependency on an invalid variable. */
     log_ctx = create_ctx_log_once("Dependency for Derivatives.Unknown incorrect. Expected continuous state variable, "
                                   "input or output. Dependency's index: '4'");
     ret |= test_parse_xml(0, argv[1], "/model_structure/invalid/derivative_deps", log_ctx, NULL);
     free_ctx_log_once(&log_ctx);
 
-    /* Test that an error is raised when a ModelStructure.InitialUnknown list
-       has a dependency to an invalid variable.
-     */
+    /* 'InitialUnknown' has a dependency on an invalid variable. */
     log_ctx = create_ctx_log_once("Dependency for InitialUnknowns.Unknown incorrect. Expected input, output, or variable with "
                                   "attribute initial='exact'. Dependency's index: '1'");
     ret |= test_parse_xml(0, argv[1], "/model_structure/invalid/initunknown_deps", log_ctx, NULL);

--- a/Test/FMI2/fmi2_import_model_structure_test.c
+++ b/Test/FMI2/fmi2_import_model_structure_test.c
@@ -1,0 +1,149 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <fmilib.h>
+#include "config_test.h"
+#include "fmil_test.h"
+
+/* Global set to 1 if logger cb found expected error message - must be reset
+ * between tests. */
+static int g_logger_found_err_msg = 0;
+
+/**
+    TODO: function copied from PR 21; extract when merged
+*/
+static char* concat(char* s1, char* s2)
+{
+    size_t len1 = strlen(s1);
+    size_t len2 = strlen(s2);
+    /* +1 for the zero-terminator */
+    char* result = (char*)malloc((len1 + len2 + 1) * sizeof(char));
+    if (result == NULL) {
+        exit(CTEST_RETURN_FAIL);
+    }
+    memcpy(result, s1, len1);
+    memcpy(result + len1, s2, len2 + 1); /* +1 to copy the null-terminator */
+    return result;
+}
+
+/**
+    TODO: function copied from PR 21; extract when merged
+*/
+static fmi2_import_t* parse_xml(const char* model_desc_path, jm_logger_f logger)
+{
+    jm_callbacks* cb = jm_get_default_callbacks();
+    fmi_import_context_t* ctx = fmi_import_allocate_context(cb);
+    fmi2_import_t* xml;
+
+    g_logger_found_err_msg = 0;
+
+    if (logger) {
+        cb->logger = logger;
+    }
+
+    if (ctx == NULL) {
+        return NULL;
+    }
+
+    xml = fmi2_import_parse_xml(ctx, model_desc_path, NULL);
+
+    fmi_import_free_context(ctx);
+    return xml;
+}
+
+/**
+    TODO: function copied from PR 21; extract when merged
+*/
+/**
+ * Tests that a unit referenced by a Type's attribute exists in UnitDefinitions.
+ *
+ * @xmlTestRootDir: path to 'parser_test_xmls' directory
+ * @xmlDirRel: Relative path to the XML directory from root dir for parser test
+ *   XMLs. Must start with leading '/' character.
+ * @logger: logger function to use. If NULL, default logger will be used.
+ * @xmlOut: return arg that will point to the parsed XML struct. Provide NULL
+ *   if not desired.
+ */
+static int test_parse_xml(int expectFailure, char* xmlTestRootDir, char* xmlDirRel, jm_logger_f logger,
+    fmi2_import_t** xmlOut)
+{
+    char* xmlDir; /* path to the XML's parent directory */
+    fmi2_import_t* xml;
+    int ret = CTEST_RETURN_SUCCESS;
+
+    xmlDir = concat(xmlTestRootDir, xmlDirRel);
+
+    xml = parse_xml(xmlDir, logger);
+    if (xml != NULL && expectFailure) {
+        ret = CTEST_RETURN_FAIL;
+        goto clean2;
+    } else if (xml == NULL && !expectFailure) {
+        ret = CTEST_RETURN_FAIL;
+        goto clean1;
+    }
+
+    if (expectFailure && !g_logger_found_err_msg) {
+        printf("Logger unexpectedly did not find error message\n");
+        ret = CTEST_RETURN_FAIL;
+    } else if (!expectFailure && g_logger_found_err_msg) {
+        printf("Logger unexpectedly found error message\n");
+        ret = CTEST_RETURN_FAIL;
+    }
+
+    if (xmlOut && ret != CTEST_RETURN_FAIL) {
+        *xmlOut = xml;
+    }
+
+clean2:
+    if (!xmlOut) {
+        fmi2_import_free(xml);
+    }
+clean1:
+    free(xmlDir);
+
+    return ret;
+}
+
+/* Tests that an error is raised when a ModelStructure.Derivatives list
+ * references a variable that doesn't have the attribute 'derivative'. */
+static void logger_invalid_state_derivative_reference(jm_callbacks* cb, jm_string module,
+        jm_log_level_enu_t log_level, jm_string message)
+{
+    char* expMsg = "The state derivative 'state_var' does not specify the state variable that it is a derivative of.";
+    if (!strncmp(expMsg, message, strlen(expMsg))) {
+        g_logger_found_err_msg = 1;
+    }
+
+    jm_default_logger(cb, module, log_level, message);
+}
+
+static int test_modelstructure_valid(fmi2_import_t* xml)
+{
+    ASSERT_MSG(xml != NULL, "Failed to parse XML");
+
+    ASSERT_MSG(fmi2_import_get_last_error(xml) != NULL, "Found unexpected error while parsing XML");
+
+    return TEST_OK;
+}
+
+int main(int argc, char **argv)
+{
+    char* xml_dir      = NULL;
+    int ret = 0;
+
+    if (argc != 2) {
+        printf("Usage: %s <path_to_'model_structure'_dir>\n", argv[0]);
+        return CTEST_RETURN_FAIL;
+    }
+
+    printf("Running fmi2_import_variable_test\n");
+
+    /* test valid */
+    ret |= test_parse_xml(0, argv[1], "/model_structure/valid", NULL, NULL);
+
+    /* test invalid */
+    ret |= test_parse_xml(1, argv[1], "/model_structure/invalid/derivative_reference",
+            logger_invalid_state_derivative_reference, NULL);
+
+    return ret;
+}

--- a/Test/FMI2/fmi2_import_model_structure_test.c
+++ b/Test/FMI2/fmi2_import_model_structure_test.c
@@ -276,7 +276,7 @@ int main(int argc, char **argv)
     /* Test that an error is raised when a ModelStructure.Outputs list
        doesn't contain a reference to all variables with causality="output".
      */
-    log_ctx = create_log_once_ctx("Output variable not found in ModelStructure.Outputs (index: 1, 0-based)");
+    log_ctx = create_log_once_ctx("Output variable not found in ModelStructure.Outputs (index: '2')");
     ret |= test_parse_xml(0, argv[1], "/model_structure/invalid/outputs_missing", log_ctx, NULL);
     free_log_once_ctx(&log_ctx);
 
@@ -284,7 +284,7 @@ int main(int argc, char **argv)
        references a variable with causality!="output".
      */
     log_ctx = create_log_once_ctx("ModelStructure.Outputs listed a variable that doesn't have "
-                                  "causality='output' (index: 0, 0-based)");
+                                  "causality='output' (index: '1')");
     ret |= test_parse_xml(0, argv[1], "/model_structure/invalid/output_reference", log_ctx, NULL);
     free_log_once_ctx(&log_ctx);
 
@@ -292,7 +292,7 @@ int main(int argc, char **argv)
        has a dependency to an invalid variable.
      */
     log_ctx = create_log_once_ctx("Dependency for Outputs.Unknown incorrect. Expected continuous state variable, "
-                                  "input or output. Dependency's index: '1' (0-based)");
+                                  "input or output. Dependency's index: '2'");
     ret |= test_parse_xml(0, argv[1], "/model_structure/invalid/output_deps", log_ctx, NULL);
     free_log_once_ctx(&log_ctx);
 
@@ -300,7 +300,7 @@ int main(int argc, char **argv)
        has a dependency to an invalid variable.
      */
     log_ctx = create_log_once_ctx("Dependency for Derivatives.Unknown incorrect. Expected continuous state variable, "
-                                  "input or output. Dependency's index: '3' (0-based)");
+                                  "input or output. Dependency's index: '4'");
     ret |= test_parse_xml(0, argv[1], "/model_structure/invalid/derivative_deps", log_ctx, NULL);
     free_log_once_ctx(&log_ctx);
 
@@ -308,16 +308,15 @@ int main(int argc, char **argv)
     /* Test that a fatal error is raised when a dependency contains an index to a non-existing variable. */
 
     /* index = 0 */
-    log_ctx = create_log_once_ctx("XML element 'Unknown': item 0=0 is less than one in the list for attribute 'dependencies'");
+    log_ctx = create_log_once_ctx("XML element 'Unknown': listed index < 1: dependencies[0]=0");
     ret |= test_parse_xml(1, argv[1], "/model_structure/invalid/dependency_not_exist_lt1", log_ctx, NULL);
     free_log_once_ctx(&log_ctx);
     /* index = -1*/
-    log_ctx = create_log_once_ctx("XML element 'Unknown': item 0=-1 is less than one in the list for attribute 'dependencies'");
+    log_ctx = create_log_once_ctx("XML element 'Unknown': listed index < 1: dependencies[0]=-1");
     ret |= test_parse_xml(1, argv[1], "/model_structure/invalid/dependency_not_exist_lt2", log_ctx, NULL);
     free_log_once_ctx(&log_ctx);
     /* index > n_vars */
-    log_ctx = create_log_once_ctx("XML element 'Unknown': item 0=2 is greater than the number of "
-                                  "ScalarVariables (1) in the list for attribute 'dependencies'");
+    log_ctx = create_log_once_ctx("XML element 'Unknown': listed index > number of ScalarVariables (1): dependencies[0]=2");
     ret |= test_parse_xml(1, argv[1], "/model_structure/invalid/dependency_not_exist_gt", log_ctx, NULL);
     free_log_once_ctx(&log_ctx);
 

--- a/Test/FMI2/fmi2_import_model_structure_test.c
+++ b/Test/FMI2/fmi2_import_model_structure_test.c
@@ -128,6 +128,12 @@ static int test_parse_xml(int expectFailure, char* xmlTestRootDir, char* xmlDirR
 
     xmlDir = concat(xmlTestRootDir, xmlDirRel);
 
+    if (!chk_log_ctx->silent) {
+        printf("\n");
+        printf("Running test in relative dir: %s\n", xmlDirRel);
+        printf("-----------------------------\n");
+    }
+
     xml = parse_xml(xmlDir, chk_log_ctx);
     if (xml != NULL && expectFailure) {
         printf("Expected parsing to fail, but didn't. XML dir: '%s'", xmlDir);
@@ -288,6 +294,31 @@ int main(int argc, char **argv)
     log_ctx = create_log_once_ctx("Dependency for Outputs.Unknown incorrect. Expected continuous state variable, "
                                   "input or output. Dependency's index: '1' (0-based)");
     ret |= test_parse_xml(0, argv[1], "/model_structure/invalid/output_deps", log_ctx, NULL);
+    free_log_once_ctx(&log_ctx);
+
+    /* Test that an error is raised when a ModelStructure.Derivatives list
+       has a dependency to an invalid variable.
+     */
+    log_ctx = create_log_once_ctx("Dependency for Derivatives.Unknown incorrect. Expected continuous state variable, "
+                                  "input or output. Dependency's index: '3' (0-based)");
+    ret |= test_parse_xml(0, argv[1], "/model_structure/invalid/derivative_deps", log_ctx, NULL);
+    free_log_once_ctx(&log_ctx);
+
+
+    /* Test that a fatal error is raised when a dependency contains an index to a non-existing variable. */
+
+    /* index = 0 */
+    log_ctx = create_log_once_ctx("XML element 'Unknown': item 0=0 is less than one in the list for attribute 'dependencies'");
+    ret |= test_parse_xml(1, argv[1], "/model_structure/invalid/dependency_not_exist_lt1", log_ctx, NULL);
+    free_log_once_ctx(&log_ctx);
+    /* index = -1*/
+    log_ctx = create_log_once_ctx("XML element 'Unknown': item 0=-1 is less than one in the list for attribute 'dependencies'");
+    ret |= test_parse_xml(1, argv[1], "/model_structure/invalid/dependency_not_exist_lt2", log_ctx, NULL);
+    free_log_once_ctx(&log_ctx);
+    /* index > n_vars */
+    log_ctx = create_log_once_ctx("XML element 'Unknown': item 0=2 is greater than the number of "
+                                  "ScalarVariables (1) in the list for attribute 'dependencies'");
+    ret |= test_parse_xml(1, argv[1], "/model_structure/invalid/dependency_not_exist_gt", log_ctx, NULL);
     free_log_once_ctx(&log_ctx);
 
     return ret;

--- a/Test/FMI2/fmu_dummy/modelDescription_me.xml
+++ b/Test/FMI2/fmu_dummy/modelDescription_me.xml
@@ -81,8 +81,6 @@
     <Unknown index="2"/>
     <Unknown index="4"/>
   </Derivatives>
-  <DiscreteStates>
-  </DiscreteStates>
   <InitialUnknowns>
   </InitialUnknowns>
 </ModelStructure>

--- a/Test/FMI2/fmu_dummy/modelDescription_me.xml
+++ b/Test/FMI2/fmu_dummy/modelDescription_me.xml
@@ -79,7 +79,7 @@
   </Outputs>
   <Derivatives>
     <Unknown index="2"/>
-    <Unknown index="4" dependencies="6" dependenciesKind="constant"/>
+    <Unknown index="4"/>
   </Derivatives>
   <DiscreteStates>
   </DiscreteStates>

--- a/Test/FMI2/parser_test_xmls/model_structure/invalid/dependency_not_exist_gt/modelDescription.xml
+++ b/Test/FMI2/parser_test_xmls/model_structure/invalid/dependency_not_exist_gt/modelDescription.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fmiModelDescription fmiVersion="2.0" modelName="myModelName" guid="myGuid">
+
+<ModelExchange modelIdentifier="myModelIdentifier"/>
+
+<ModelVariables>
+  <!-- idx: 1 -->
+  <ScalarVariable name="output_var" valueReference="0" causality="output" variability="continuous">
+    <Real/>
+  </ScalarVariable>
+</ModelVariables>
+
+<ModelStructure>
+  <Outputs>
+    <Unknown index="1" dependencies="2"/> <!-- invalid: index=2 is greater than number of variables -->
+  </Outputs>
+</ModelStructure>
+</fmiModelDescription>

--- a/Test/FMI2/parser_test_xmls/model_structure/invalid/dependency_not_exist_lt1/modelDescription.xml
+++ b/Test/FMI2/parser_test_xmls/model_structure/invalid/dependency_not_exist_lt1/modelDescription.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fmiModelDescription fmiVersion="2.0" modelName="myModelName" guid="myGuid">
+
+<ModelExchange modelIdentifier="myModelIdentifier"/>
+
+<ModelVariables>
+  <!-- idx: 1 -->
+  <ScalarVariable name="output_var" valueReference="0" causality="output" variability="continuous">
+    <Real/>
+  </ScalarVariable>
+</ModelVariables>
+
+<ModelStructure>
+  <Outputs>
+    <Unknown index="1" dependencies="0"/> <!-- invalid: index=0 is less than number of variables -->
+  </Outputs>
+</ModelStructure>
+</fmiModelDescription>

--- a/Test/FMI2/parser_test_xmls/model_structure/invalid/dependency_not_exist_lt2/modelDescription.xml
+++ b/Test/FMI2/parser_test_xmls/model_structure/invalid/dependency_not_exist_lt2/modelDescription.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fmiModelDescription fmiVersion="2.0" modelName="myModelName" guid="myGuid">
+
+<ModelExchange modelIdentifier="myModelIdentifier"/>
+
+<ModelVariables>
+  <!-- idx: 1 -->
+  <ScalarVariable name="output_var" valueReference="0" causality="output" variability="continuous">
+    <Real/>
+  </ScalarVariable>
+</ModelVariables>
+
+<ModelStructure>
+  <Outputs>
+    <Unknown index="1" dependencies="-1"/> <!-- invalid: index=-1 is less than number of variables -->
+  </Outputs>
+</ModelStructure>
+</fmiModelDescription>

--- a/Test/FMI2/parser_test_xmls/model_structure/invalid/derivative_deps/modelDescription.xml
+++ b/Test/FMI2/parser_test_xmls/model_structure/invalid/derivative_deps/modelDescription.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <fmiModelDescription fmiVersion="2.0" modelName="myModelName" guid="myGuid">
 
-<ModelExchange
-  modelIdentifier="myModelIdentifier"/>
+<ModelExchange modelIdentifier="myModelIdentifier"/>
 
 <ModelVariables>
   <!-- idx: 1 -->
@@ -11,22 +10,19 @@
   </ScalarVariable>
   <!-- idx: 2 -->
   <ScalarVariable name="der(state_var)" valueReference="1" causality="output" variability="continuous" initial="approx">
-    <Real derivative="1" start="0.0"/>
+    <Real derivative="1" start="1.0"/>
   </ScalarVariable>
   <!-- idx: 3 -->
   <ScalarVariable name="indep_var" valueReference="2" causality="independent">
     <Real start="0.0"/>
   </ScalarVariable>
   <!-- idx: 4 -->
-  <ScalarVariable name="input_var" valueReference="3" causality="input">
+  <ScalarVariable name="local_var1" valueReference="3" causality="local" initial="exact">
     <Real start="0.0"/>
   </ScalarVariable>
 </ModelVariables>
 
 <ModelStructure>
-  <Outputs>
-    <Unknown index="2" dependencies="1 3 4"/>
-  </Outputs>
   <Derivatives>
     <Unknown index="2" dependencies="1 3 4"/>
   </Derivatives>

--- a/Test/FMI2/parser_test_xmls/model_structure/invalid/derivative_reference/modelDescription.xml
+++ b/Test/FMI2/parser_test_xmls/model_structure/invalid/derivative_reference/modelDescription.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fmiModelDescription
+  fmiVersion="2.0"
+  modelName="myModelName"
+  guid="myGuid"
+  description="myDescription"
+  author="myAuthor"
+  generationTool="myGenerationTool"
+  generationDateAndTime="2002-05-30T09:00:00"
+  version="myModelVersion"
+  variableNamingConvention="structured"
+  numberOfEventIndicators="3">
+
+<ModelExchange
+  modelIdentifier="myModelIdentifier" />
+
+<ModelVariables>
+    <!-- idx: 1 -->
+    <ScalarVariable name="state_var" valueReference="0">
+      <Real/>
+    </ScalarVariable>
+    <!-- idx: 2 -->
+    <ScalarVariable name="der(state_var)" valueReference="1" causality="output" variability="continuous" initial="approx">
+      <Real derivative="1" start="1.0"/>
+    </ScalarVariable>
+</ModelVariables>
+
+<ModelStructure>
+  <Derivatives>
+    <Unknown index="1"/> <!-- Invalid: referenced variable is not a derivative  -->
+    <Unknown index="2"/>
+  </Derivatives>
+</ModelStructure>
+</fmiModelDescription>

--- a/Test/FMI2/parser_test_xmls/model_structure/invalid/initunknown_deps/modelDescription.xml
+++ b/Test/FMI2/parser_test_xmls/model_structure/invalid/initunknown_deps/modelDescription.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <fmiModelDescription fmiVersion="2.0" modelName="myModelName" guid="myGuid">
 
-<ModelExchange
-  modelIdentifier="myModelIdentifier"/>
+<ModelExchange modelIdentifier="myModelIdentifier"/>
 
 <ModelVariables>
   <!-- idx: 1 -->
@@ -11,31 +10,21 @@
   </ScalarVariable>
   <!-- idx: 2 -->
   <ScalarVariable name="der(state_var)" valueReference="1" causality="output" variability="continuous" initial="approx">
-    <Real derivative="1" start="0.0"/>
+    <Real derivative="1" start="1.0"/>
   </ScalarVariable>
   <!-- idx: 3 -->
   <ScalarVariable name="indep_var" valueReference="2" causality="independent">
     <Real start="0.0"/>
   </ScalarVariable>
   <!-- idx: 4 -->
-  <ScalarVariable name="input_var" valueReference="3" causality="input">
-    <Real start="0.0"/>
-  </ScalarVariable>
-  <!-- idx: 5 -->
-  <ScalarVariable name="param_var" valueReference="4" causality="parameter" variability="fixed" initial="exact">
+  <ScalarVariable name="local_var1" valueReference="3" causality="local" initial="exact">
     <Real start="0.0"/>
   </ScalarVariable>
 </ModelVariables>
 
 <ModelStructure>
-  <Outputs>
-    <Unknown index="2" dependencies="1 3 4"/>
-  </Outputs>
-  <Derivatives>
-    <Unknown index="2" dependencies="1 3 4"/>
-  </Derivatives>
   <InitialUnknowns>
-    <Unknown index="2" dependencies="3 4 5"/>
+    <Unknown index="2" dependencies="1 3 4"/> <!-- invalid: index=1 is not valid -->
   </InitialUnknowns>
 </ModelStructure>
 </fmiModelDescription>

--- a/Test/FMI2/parser_test_xmls/model_structure/invalid/output_deps/modelDescription.xml
+++ b/Test/FMI2/parser_test_xmls/model_structure/invalid/output_deps/modelDescription.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fmiModelDescription fmiVersion="2.0" modelName="myModelName" guid="myGuid">
+
+<ModelExchange modelIdentifier="myModelIdentifier"/>
+
+<ModelVariables>
+  <!-- idx: 1 -->
+  <ScalarVariable name="output_var1" valueReference="0" causality="output" initial="calculated">
+    <Real/>
+  </ScalarVariable>
+  <!-- idx: 2 -->
+  <ScalarVariable name="local_var1" valueReference="1" causality="local" initial="exact">
+    <Real start="1"/>
+  </ScalarVariable>
+  <!-- idx: 3 -->
+  <ScalarVariable name="input_var1" valueReference="2" causality="input">
+    <Real start="1"/>
+  </ScalarVariable>
+</ModelVariables>
+
+<ModelStructure>
+  <Outputs>
+    <Unknown index="1" dependencies="2 3"/> <!-- invalid: index 2 is a local variable -->
+  </Outputs>
+</ModelStructure>
+</fmiModelDescription>

--- a/Test/FMI2/parser_test_xmls/model_structure/invalid/output_reference/modelDescription.xml
+++ b/Test/FMI2/parser_test_xmls/model_structure/invalid/output_reference/modelDescription.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fmiModelDescription fmiVersion="2.0" modelName="myModelName" guid="myGuid">
+
+<ModelExchange modelIdentifier="myModelIdentifier" />
+
+<ModelVariables>
+    <!-- idx: 1 -->
+    <ScalarVariable name="output_var1" valueReference="0">
+      <Real/>
+    </ScalarVariable>
+</ModelVariables>
+
+<ModelStructure>
+  <Outputs>
+    <Unknown index="1"/> <!-- invalid: variable is not an output -->
+  </Outputs>
+</ModelStructure>
+</fmiModelDescription>

--- a/Test/FMI2/parser_test_xmls/model_structure/invalid/outputs_missing/modelDescription.xml
+++ b/Test/FMI2/parser_test_xmls/model_structure/invalid/outputs_missing/modelDescription.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fmiModelDescription fmiVersion="2.0" modelName="myModelName" guid="myGuid">
+
+<ModelExchange modelIdentifier="myModelIdentifier" />
+
+<ModelVariables>
+    <!-- idx: 1 -->
+    <ScalarVariable name="output_var1" valueReference="0" causality="output" initial="calculated">
+      <Real/>
+    </ScalarVariable>
+    <!-- idx: 2 -->
+    <ScalarVariable name="output_var2" valueReference="1" causality="output" initial="calculated">
+      <Real/>
+    </ScalarVariable>
+</ModelVariables>
+
+<ModelStructure>
+  <Outputs> <!-- invalid: index="2" is missing -->
+    <Unknown index="1"/>
+  </Outputs>
+</ModelStructure>
+</fmiModelDescription>

--- a/Test/FMI2/parser_test_xmls/model_structure/valid/modelDescription.xml
+++ b/Test/FMI2/parser_test_xmls/model_structure/valid/modelDescription.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fmiModelDescription
+  fmiVersion="2.0"
+  modelName="myModelName"
+  guid="myGuid"
+  description="myDescription"
+  author="myAuthor"
+  generationTool="myGenerationTool"
+  generationDateAndTime="2002-05-30T09:00:00"
+  version="myModelVersion"
+  variableNamingConvention="structured"
+  numberOfEventIndicators="3">
+
+<ModelExchange
+  modelIdentifier="myModelIdentifier" />
+
+<ModelVariables>
+    <!-- idx: 1 -->
+    <ScalarVariable name="state_var" valueReference="0">
+      <Real/>
+    </ScalarVariable>
+    <!-- idx: 2 -->
+    <ScalarVariable name="der(state_var)" valueReference="1" causality="output" variability="continuous" initial="approx">
+      <Real derivative="1" start="1.0"/>
+    </ScalarVariable>
+</ModelVariables>
+
+<ModelStructure>
+  <Derivatives>
+    <Unknown index="2"/>
+  </Derivatives>
+</ModelStructure>
+</fmiModelDescription>

--- a/Test/FMI2/parser_test_xmls/model_structure/valid/modelDescription.xml
+++ b/Test/FMI2/parser_test_xmls/model_structure/valid/modelDescription.xml
@@ -1,18 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fmiModelDescription
-  fmiVersion="2.0"
-  modelName="myModelName"
-  guid="myGuid"
-  description="myDescription"
-  author="myAuthor"
-  generationTool="myGenerationTool"
-  generationDateAndTime="2002-05-30T09:00:00"
-  version="myModelVersion"
-  variableNamingConvention="structured"
-  numberOfEventIndicators="3">
+<fmiModelDescription fmiVersion="2.0" modelName="myModelName" guid="myGuid">
 
 <ModelExchange
-  modelIdentifier="myModelIdentifier" />
+  modelIdentifier="myModelIdentifier"/>
 
 <ModelVariables>
     <!-- idx: 1 -->
@@ -21,11 +11,22 @@
     </ScalarVariable>
     <!-- idx: 2 -->
     <ScalarVariable name="der(state_var)" valueReference="1" causality="output" variability="continuous" initial="approx">
-      <Real derivative="1" start="1.0"/>
+      <Real derivative="1" start="0.0"/>
+    </ScalarVariable>
+    <!-- idx: 3 -->
+    <ScalarVariable name="indep_var" valueReference="2" causality="independent">
+      <Real start="0.0"/>
+    </ScalarVariable>
+    <!-- idx: 4 -->
+    <ScalarVariable name="input_var" valueReference="3" causality="input">
+      <Real start="0.0"/>
     </ScalarVariable>
 </ModelVariables>
 
 <ModelStructure>
+  <Outputs>
+    <Unknown index="2" dependencies="1 3 4"/>
+  </Outputs>
   <Derivatives>
     <Unknown index="2"/>
   </Derivatives>

--- a/src/Import/include/FMI2/fmi2_import.h
+++ b/src/Import/include/FMI2/fmi2_import.h
@@ -68,7 +68,7 @@ extern "C" {
 * Error handling:
 *
 *  Many functions in the library return pointers to struct. An error is indicated by returning NULL/0-pointer.
-*  If error is returned than fmi2_import_get_last_error() functions can be used to retrieve the error message.
+*  If error is returned then fmi2_import_get_last_error() functions can be used to retrieve the error message.
 *  If logging callbacks were specified then the same information is reported via logger.
 *  Memory for the error string is allocated and deallocated in the module.
 *  Client code should not store the pointer to the string since it can become invalid.

--- a/src/Import/include/FMI2/fmi2_import.h
+++ b/src/Import/include/FMI2/fmi2_import.h
@@ -312,14 +312,6 @@ FMILIB_EXPORT fmi2_import_variable_list_t* fmi2_import_get_outputs_list(fmi2_imp
 */
 FMILIB_EXPORT fmi2_import_variable_list_t* fmi2_import_get_derivatives_list(fmi2_import_t* fmu);
 
-/** \brief Get the list of all the discrete state variables in the model.
-* @param fmu An FMU object as returned by fmi2_import_parse_xml().
-* @return a variable list with all the discrete state variables in the model.
-*
-* Note that variable lists are allocated dynamically and must be freed when not needed any longer.
-*/
-FMILIB_EXPORT fmi2_import_variable_list_t* fmi2_import_get_discrete_states_list(fmi2_import_t* fmu);
-
 /** \brief Get the list of all the initial unknown variables in the model.
 * @param fmu An FMU object as returned by fmi2_import_parse_xml().
 * @return a variable list with all the initial unknowns in the model.
@@ -349,17 +341,6 @@ FMILIB_EXPORT void fmi2_import_get_outputs_dependencies(fmi2_import_t* fmu, size
  * @param factorKind - outputs a pointer to the factor kind data. The values can be converted to ::fmi2_dependency_factor_kind_enu_t 
  */ 
 FMILIB_EXPORT void fmi2_import_get_derivatives_dependencies(fmi2_import_t* fmu, size_t** startIndex, size_t** dependency, char** factorKind);
-
-/** \brief Get dependency information in row-compressed format. 
- * @param fmu An FMU object as returned by fmi2_import_parse_xml(). 
- * @param startIndex - outputs a pointer to an array of start indices (size of array is number of discrete states + 1).
- *                     First element is zero, last is equal to the number of elements in the dependency and factor arrays. 
- *                     NULL pointer is returned if no dependency information was provided in the XML. 
- * @param dependency - outputs a pointer to the dependency index data. Indices are 1-based. Index equals to zero  
- *                     means "depends on all" (no information in the XML). 
- * @param factorKind - outputs a pointer to the factor kind data. The values can be converted to ::fmi2_dependency_factor_kind_enu_t 
- */ 
-FMILIB_EXPORT void fmi2_import_get_discrete_states_dependencies(fmi2_import_t* fmu, size_t** startIndex, size_t** dependency, char** factorKind);
  
 /** \brief Get dependency information in row-compressed format. 
  * @param fmu An FMU object as returned by fmi2_import_parse_xml(). 

--- a/src/Import/include/FMI2/fmi2_import_variable.h
+++ b/src/Import/include/FMI2/fmi2_import_variable.h
@@ -222,7 +222,11 @@ FMILIB_EXPORT int fmi2_import_get_enum_variable_max(fmi2_import_enum_variable_t*
 /** \brief Get the variable alias kind*/
 FMILIB_EXPORT fmi2_variable_alias_kind_enu_t fmi2_import_get_variable_alias_kind(fmi2_import_variable_t*);
 
-/** \brief Get the original index in xml of the variable */
+/** \brief Get the original index in xml of the variable. Note that the
+    returned index is 0-based, and that the standard specifies it as 1-based.
+    The returned index will dereference the 'original-order' list returned by
+    'fmi2_import_get_variable_list' correctly.
+*/
 FMILIB_EXPORT size_t fmi2_import_get_variable_original_order(fmi2_import_variable_t* v);
 
 /** @} */

--- a/src/Import/src/FMI2/fmi2_import.c
+++ b/src/Import/src/FMI2/fmi2_import.c
@@ -416,11 +416,6 @@ fmi2_import_variable_list_t* fmi2_import_get_derivatives_list(fmi2_import_t* fmu
 	return fmi2_import_vector_to_varlist(fmu, fmi2_xml_get_derivatives(fmi2_xml_get_model_structure(fmu->md)));
 }
 
-fmi2_import_variable_list_t* fmi2_import_get_discrete_states_list(fmi2_import_t* fmu) {
-	if(!fmi2_import_check_has_FMU(fmu)) return 0;
-	return fmi2_import_vector_to_varlist(fmu, fmi2_xml_get_discrete_states(fmi2_xml_get_model_structure(fmu->md)));
-}
-
 fmi2_import_variable_list_t* fmi2_import_get_initial_unknowns_list(fmi2_import_t* fmu) {
 	if(!fmi2_import_check_has_FMU(fmu)) return 0;
 	return fmi2_import_vector_to_varlist(fmu, fmi2_xml_get_initial_unknowns(fmi2_xml_get_model_structure(fmu->md)));
@@ -446,17 +441,6 @@ void fmi2_import_get_derivatives_dependencies(fmi2_import_t* fmu,size_t** startI
     ms = fmi2_xml_get_model_structure(fmu->md);
     assert(ms);
     fmi2_xml_get_derivatives_dependencies(ms, startIndex, dependency, factorKind); 
-} 
-
-void fmi2_import_get_discrete_states_dependencies(fmi2_import_t* fmu,size_t** startIndex, size_t** dependency, char** factorKind) { 
-    fmi2_xml_model_structure_t* ms; 
-    if(!fmi2_import_check_has_FMU(fmu)) {
-        *startIndex = 0;
-        return;
-    }    
-    ms = fmi2_xml_get_model_structure(fmu->md);
-    assert(ms);
-    fmi2_xml_get_discrete_states_dependencies(ms, startIndex, dependency, factorKind); 
 } 
 
 void fmi2_import_get_initial_unknowns_dependencies(fmi2_import_t* fmu,size_t** startIndex, size_t** dependency, char** factorKind) { 

--- a/src/Util/include/JM/jm_vector.h
+++ b/src/Util/include/JM/jm_vector.h
@@ -171,7 +171,7 @@ Default definition below is jm_diff and is implemented as (int)(first-second)
 
 /**
   jm_vector_bsearch uses standard binary search (bsearch) to find elements in a sorted vector.
-  It returns the index of an item in the vector or vector's size if not found.
+  jm_vector_bsearch_index returns the index of an item in the vector or vector's size if not found.
     JM_COMPAR_OP is used for comparison.
 
   T* jm_vector_bsearch(T)(jm_vector(T)* v, T* key, jm_compare_ft f)

--- a/src/XML/include/FMI2/fmi2_xml_model_structure.h
+++ b/src/XML/include/FMI2/fmi2_xml_model_structure.h
@@ -42,12 +42,6 @@ jm_vector(jm_voidp)* fmi2_xml_get_outputs(fmi2_xml_model_structure_t* ms);
 */
 jm_vector(jm_voidp)* fmi2_xml_get_derivatives(fmi2_xml_model_structure_t* ms);
 
-/** \brief Get the list of all the discrete state variables in the model.
-* @param ms A model structure pointer (returned by fmi2_xml_get_model_structure)
-* @return a variable list with all the discrete state variables in the model.
-*/
-jm_vector(jm_voidp)* fmi2_xml_get_discrete_states(fmi2_xml_model_structure_t* ms);
-
 /** \brief Get the list of all the initial unknown variables in the model.
 * @param ms A model structure pointer (returned by fmi2_xml_get_model_structure)
 * @return a variable list with all the initial unknowns in the model.
@@ -73,16 +67,6 @@ void fmi2_xml_get_outputs_dependencies(fmi2_xml_model_structure_t* ms, size_t** 
  * @param factorKind - outputs a pointer to the factor kind data. The values can be converted to ::fmi2_dependency_factor_kind_enu_t 
  */ 
 void fmi2_xml_get_derivatives_dependencies(fmi2_xml_model_structure_t* ms, size_t** startIndex, size_t** dependency, char** factorKind);
-
-/** \brief Get dependency information in row-compressed format. 
- * @param startIndex - outputs a pointer to an array of start indices (size of array is number of discrete states + 1).
- *                     First element is zero, last is equal to the number of elements in the dependency and factor arrays. 
- *                     NULL pointer is returned if no dependency information was provided in the XML. 
- * @param dependency - outputs a pointer to the dependency index data. Indices are 1-based. Index equals to zero  
- *                     means "depends on all" (no information in the XML). 
- * @param factorKind - outputs a pointer to the factor kind data. The values can be converted to ::fmi2_dependency_factor_kind_enu_t 
- */ 
-void fmi2_xml_get_discrete_states_dependencies(fmi2_xml_model_structure_t* ms, size_t** startIndex, size_t** dependency, char** factorKind);
  
 /** \brief Get dependency information in row-compressed format. 
  * @param startIndex - outputs a pointer to an array of start indices (size of array is number of initial unknowns + 1).

--- a/src/XML/src/FMI2/fmi2_xml_model_structure.c
+++ b/src/XML/src/FMI2/fmi2_xml_model_structure.c
@@ -220,17 +220,18 @@ static void fmi2_xml_check_dependency_initialunknown(fmi2_xml_parser_context_t* 
     }
 }
 
-/** Checks that dependencies are valid for Unknown elements in Outputs or
-    Derivatives elements.
+/**
+   Checks that dependencies are valid for Unknown elements in Outputs or
+   Derivatives elements.
 
-    @contStateIndices:
-      Sorted vector with 0-based indices to all continuous state variables.
-    @unknownList:
-      Either 'ms->outputs' or 'ms->derivatives'.
-    @deps:
-      Either 'ms->outputDeps' or 'ms->derivativeDeps'.
-    @elemName:
-      Name of the element, i.e. "Outputs" or "Dependencies".
+   @contStateIndices:
+     Sorted vector with 0-based indices to all continuous state variables.
+   @unknownList:
+     Either 'ms->outputs' or 'ms->derivatives'.
+   @deps:
+     Either 'ms->outputDeps' or 'ms->derivativeDeps'.
+   @elemName:
+     Name of the element, i.e. "Outputs" or "Dependencies".
 */
 static void fmi2_xml_check_unknownlist_dependencies(fmi2_xml_parser_context_t* context,
         fmi2_xml_dependency_checker_t* depChecker, fmi2_xml_dependencies_t* deps, size_t nUnknowns)

--- a/src/XML/src/FMI2/fmi2_xml_model_structure.c
+++ b/src/XML/src/FMI2/fmi2_xml_model_structure.c
@@ -214,8 +214,8 @@ static void fmi2_xml_check_outputs_or_derivatives_dependencies(fmi2_xml_parser_c
                 valid |= (fmi2_causality_enu_t)dep->causality == fmi2_causality_enu_input;
                 if (!valid) {
                     fmi2_xml_parse_error(context, "Dependency for %s.Unknown incorrect. "
-                            "Expected continuous state variable, input or output. Dependency's index: '%u' (0-based)",
-                            elemName, idx);
+                            "Expected continuous state variable, input or output. Dependency's index: '%u'",
+                            elemName, idx + 1); /* convert to 1-based */
                 }
             }
         }
@@ -313,8 +313,8 @@ static void fmi2_xml_verify_outputs_idx_list_is_complete(fmi2_xml_parser_context
         if (fmi2_xml_get_causality(var) == fmi2_causality_enu_output) {
             size_t svIdx = var->originalIndex;
             if (!jm_vector_bsearch(size_t)(&msOutIdxs, &svIdx, jm_compare_size_t)) {
-                fmi2_xml_parse_error(context, "Output variable not found in ModelStructure.Outputs (index: %u, 0-based)",
-                        svIdx);
+                fmi2_xml_parse_error(context, "Output variable not found in ModelStructure.Outputs (index: '%u')",
+                        svIdx + 1); /* convert to 1-based */
             }
         }
     }
@@ -402,17 +402,16 @@ int fmi2_xml_parse_dependencies(fmi2_xml_parser_context_t *context,
                 ms->isValidFlag = 0;
                 return 0;
              }
-             /* Out-of-bounds indicies cause fatal, since this has a high risk of otherwise cause segfaults later */
+             /* Out-of-bounds indices cause fatal, since this has a high risk of otherwise cause segfaults later */
              if(ind < 1) {
-                 fmi2_xml_parse_fatal(context, "XML element 'Unknown': item %d=%d is less than one in the list for attribute 'dependencies'",
+                 fmi2_xml_parse_fatal(context, "XML element 'Unknown': listed index < 1: dependencies[%d]=%d",
                      numDepInd, ind);
                 ms->isValidFlag = 0;
                 return 0;
              }
-             if(ind > numVars) {
-                 fmi2_xml_parse_fatal(context, "XML element 'Unknown': item %d=%d is greater than the number of "
-                                               "ScalarVariables (%u) in the list for attribute 'dependencies'",
-                                               numDepInd, ind, numVars);
+             if((size_t)ind > numVars) { /* typecast is safe since we know: ind >= 1 */
+                 fmi2_xml_parse_fatal(context, "XML element 'Unknown': listed index > number of ScalarVariables (%u): dependencies[%d]=%d",
+                     numVars, numDepInd, ind);
                 ms->isValidFlag = 0;
                 return 0;
              }
@@ -546,8 +545,8 @@ static void fmi2_xml_verify_unknown_output(fmi2_xml_parser_context_t *context, f
 {
     if (var->causality != fmi2_causality_enu_output) {
         fmi2_xml_parse_error(context,
-                "ModelStructure.Outputs listed a variable that doesn't have causality='output' (index: %u, 0-based)",
-                 fmi2_xml_get_variable_original_order(var));
+                "ModelStructure.Outputs listed a variable that doesn't have causality='output' (index: '%u')",
+                 fmi2_xml_get_variable_original_order(var) + 1); /* convert to 1-based */
     }
 }
 

--- a/src/XML/src/FMI2/fmi2_xml_model_structure_impl.h
+++ b/src/XML/src/FMI2/fmi2_xml_model_structure_impl.h
@@ -47,12 +47,10 @@ void fmi2_xml_free_dependencies(fmi2_xml_dependencies_t* dep);
 struct fmi2_xml_model_structure_t {
 	jm_vector(jm_voidp) outputs;
 	jm_vector(jm_voidp) derivatives;
-	jm_vector(jm_voidp) discreteStates;
 	jm_vector(jm_voidp) initialUnknowns;
 
     fmi2_xml_dependencies_t* outputDeps;
     fmi2_xml_dependencies_t* derivativeDeps;
-    fmi2_xml_dependencies_t* discreteStateDeps;
     fmi2_xml_dependencies_t* initialUnknownDeps;
 
 	int isValidFlag;  /**\ brief The flag is used to signal if an error was discovered and the model structure is not usable */

--- a/src/XML/src/FMI2/fmi2_xml_parser.c
+++ b/src/XML/src/FMI2/fmi2_xml_parser.c
@@ -65,8 +65,6 @@ const char *fmi2_xmlAttrNames[fmi2_xml_attr_number] = {
 #define fmi2_xml_scheme_Unknown {fmi2_xml_elmID_Outputs, 0, 1}
 #define fmi2_xml_scheme_Derivatives {fmi2_xml_elmID_ModelStructure, 1, 0}
 #define fmi2_xml_scheme_DerivativeUnknown {fmi2_xml_elmID_Derivatives, 0, 1}
-#define fmi2_xml_scheme_DiscreteStates {fmi2_xml_elmID_ModelStructure, 2, 0}
-#define fmi2_xml_scheme_DiscreteStateUnknown {fmi2_xml_elmID_DiscreteStates, 0, 1}
 #define fmi2_xml_scheme_InitialUnknowns {fmi2_xml_elmID_ModelStructure, 3, 0}
 #define fmi2_xml_scheme_InitialUnknown {fmi2_xml_elmID_InitialUnknowns, 0, 1}
 

--- a/src/XML/src/FMI2/fmi2_xml_parser.h
+++ b/src/XML/src/FMI2/fmi2_xml_parser.h
@@ -125,7 +125,6 @@ typedef enum fmi2_xml_attr_enu_t {
     EXPAND_XML_ELMNAME(ModelStructure) \
     EXPAND_XML_ELMNAME(Outputs) \
     EXPAND_XML_ELMNAME(Derivatives) \
-    EXPAND_XML_ELMNAME(DiscreteStates) \
     EXPAND_XML_ELMNAME(InitialUnknowns) \
     EXPAND_XML_ELMNAME(Unknown)
 
@@ -141,7 +140,6 @@ typedef enum fmi2_xml_attr_enu_t {
     EXPAND_XML_ELMNAME(SourceFilesCS) \
     EXPAND_XML_ELMNAME(FileCS) \
     EXPAND_XML_ELMNAME(DerivativeUnknown) \
-    EXPAND_XML_ELMNAME(DiscreteStateUnknown) \
     EXPAND_XML_ELMNAME(InitialUnknown)
 
 

--- a/src/XML/src/FMI2/fmi2_xml_variable_impl.h
+++ b/src/XML/src/FMI2/fmi2_xml_variable_impl.h
@@ -32,7 +32,8 @@ struct fmi2_xml_variable_t {
 
     const char* description;				 /** \brief Associate description */
 
-	size_t originalIndex;					/** \brief Index in the model description */
+	size_t originalIndex;					/** \brief Index in the model description.
+                                                 NOTE: 0-based, but standard is 1-based. */
 
     /* NB: before parsing of <ModelVariables> has finished,
            derivativeOf and previous are stored as integer indices cast to pointers,


### PR DESCRIPTION
Adding ModelStructure verification:

    1.
        a. MS.Outputs.Unknown.index must be an output  # (issues/23)
        b. MV.SV.causality="output" must exist in MS.Outputs.Unknown.index  # (issues/23)
    2. MS.Outputs.Unknown.dependencies[i] must be a valid dependency  # (issues/23)
    3. MS.Derivatives.Unknown.dependencies[i] must be a valid dependency  # (no explicit issue, but related to issues/23)
    4. MS.InitialUnknowns.Unknown.dependencies[i] must be a valid dependency  # (no explicit issue, but related to both issues)
    5. MS.InitialUnknown.index must be valid  # (issues/27, also noted in first comment in issues/23)


Intends to solve Checker github issues:
  - https://github.com/modelica-tools/FMUComplianceChecker/issues/23
  - https://github.com/modelica-tools/FMUComplianceChecker/issues/27
    - 'Error1' is already fixed