### PR TITLE
Fix heap corruption for Binary array variables on MinGW

### DIFF
--- a/Test/FMI3/parser_test_xmls/arrays/valid/big1/modelDescription.xml
+++ b/Test/FMI3/parser_test_xmls/arrays/valid/big1/modelDescription.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <fmiModelDescription fmiVersion="3.0" modelName="" instantiationToken="">
 
-  <CoSimulation modelIdentifier=""/>
+  <CoSimulation modelIdentifier="modelIdentifier"/>
 
   <ModelVariables>
     <Int64 name="int64_array_100" valueReference="118" causality="input"


### PR DESCRIPTION
There was a warning:
```
<...>/src/XML/src/FMI3/fmi3_xml_variable.c:1025:26: warning: unknown conversion type character 'h' in format [-Wformat=]

         if (!sscanf(pos, "%2hhx", &bytearr[i])) {
```
and some more secondary errors.