### PR TITLE
Rename _get_variable_initial -> _get_initial

### DIFF
--- a/Test/FMI3/fmi3_import_model_structure_test.cpp
+++ b/Test/FMI3/fmi3_import_model_structure_test.cpp
@@ -138,9 +138,9 @@ static void test_fmi3_import_get_clocked_states(fmi3_import_t* fmu) {
     fmi3_import_free_variable_list(varList);
 }
 
-static void test_fmi3_import_get_variable_initial_unknowns(fmi3_import_t* fmu) {
+static void test_fmi3_import_get_initial_unknowns(fmi3_import_t* fmu) {
 
-    fmi3_import_variable_list_t* varList = fmi3_import_get_variable_initial_unknowns_list(fmu);
+    fmi3_import_variable_list_t* varList = fmi3_import_get_initial_unknowns_list(fmu);
     REQUIRE(fmi3_import_get_variable_list_size(varList) == 1);
 
     /* check VRs and dependencies of all InitialUnknowns */
@@ -151,7 +151,7 @@ static void test_fmi3_import_get_variable_initial_unknowns(fmi3_import_t* fmu) {
 
     fmi3_import_variable_t* var = fmi3_import_get_variable(varList, 0);
     REQUIRE(fmi3_import_get_variable_vr(var) == 1);
-    REQUIRE(fmi3_import_get_variable_initial_unknown_dependencies(fmu, var, &numDependencies, &dependsOnAll, &dependencies, &dependenciesKind) == 0);
+    REQUIRE(fmi3_import_get_initial_unknown_dependencies(fmu, var, &numDependencies, &dependsOnAll, &dependencies, &dependenciesKind) == 0);
     REQUIRE(numDependencies == 0);
     REQUIRE(dependsOnAll == 1);
     REQUIRE(dependencies == nullptr);
@@ -228,7 +228,7 @@ TEST_CASE("Valid ModelStructure parsing") {
     }
 
     SECTION("Get InitialUnknowns") {
-        test_fmi3_import_get_variable_initial_unknowns(fmu);
+        test_fmi3_import_get_initial_unknowns(fmu);
     }
 
     SECTION("Get EventIndicators") {

--- a/src/Import/include/FMI3/fmi3_import.h
+++ b/src/Import/include/FMI3/fmi3_import.h
@@ -336,7 +336,7 @@ FMILIB_EXPORT fmi3_import_variable_list_t* fmi3_import_get_clocked_states_list(f
 *
 * Note that variable lists are allocated dynamically and must be freed when not needed any longer.
 */
-FMILIB_EXPORT fmi3_import_variable_list_t* fmi3_import_get_variable_initial_unknowns_list(fmi3_import_t* fmu);
+FMILIB_EXPORT fmi3_import_variable_list_t* fmi3_import_get_initial_unknowns_list(fmi3_import_t* fmu);
 
 /** \brief Get the list of all the event indicator variables in the model.
 * @param fmu An FMU object as returned by fmi3_import_parse_xml().
@@ -387,7 +387,7 @@ FMILIB_EXPORT int fmi3_import_get_clocked_state_dependencies(fmi3_import_t* fmu,
 
 /** \brief Get dependency information for an InitialUnknown.
  * @param fmu              - An FMU object as returned by fmi3_import_parse_xml().
- * @param variable         - A model variable in fmi3_import_get_variable_initial_unknowns_list(...)
+ * @param variable         - A model variable in fmi3_import_get_initial_unknowns_list(...)
  * @param numDependencies  - outputs number of dependencies; 0 for no dependencies and depends on all, check 'dependsOnAll' output
  * @param dependsOnAll     - outputs 1 if a variable depends on all variables, else 0. Only relevant if numDependencies == 0
  * @param dependencies     - outputs a pointer to the dependencies (valueReferences), NULL if numDependencies == 0
@@ -395,7 +395,7 @@ FMILIB_EXPORT int fmi3_import_get_clocked_state_dependencies(fmi3_import_t* fmu,
  *                           NULL if numDependencies == 0
  * @return                 - non-zero if variable cannot be found (e.g., not an InitialUnknown), invalid inputs or unexpected failures
  */
-FMILIB_EXPORT int fmi3_import_get_variable_initial_unknown_dependencies(fmi3_import_t* fmu, fmi3_import_variable_t* variable,
+FMILIB_EXPORT int fmi3_import_get_initial_unknown_dependencies(fmi3_import_t* fmu, fmi3_import_variable_t* variable,
         size_t* numDependencies, int* dependsOnAll, size_t** dependencies, char** dependenciesKind);
 
 /** \brief Get dependency information for an EventIndicator.

--- a/src/Import/src/FMI3/fmi3_import.c
+++ b/src/Import/src/FMI3/fmi3_import.c
@@ -432,9 +432,9 @@ fmi3_import_variable_list_t* fmi3_import_get_clocked_states_list(fmi3_import_t* 
     return fmi3_import_vector_to_varlist(fmu, fmi3_xml_get_clocked_states(fmi3_xml_get_model_structure(fmu->md)));
 }
 
-fmi3_import_variable_list_t* fmi3_import_get_variable_initial_unknowns_list(fmi3_import_t* fmu) {
+fmi3_import_variable_list_t* fmi3_import_get_initial_unknowns_list(fmi3_import_t* fmu) {
     if (!fmi3_import_check_has_FMU(fmu)) return NULL;
-    return fmi3_import_vector_to_varlist(fmu, fmi3_xml_get_variable_initial_unknowns(fmi3_xml_get_model_structure(fmu->md)));
+    return fmi3_import_vector_to_varlist(fmu, fmi3_xml_get_initial_unknowns(fmi3_xml_get_model_structure(fmu->md)));
 }
 
 fmi3_import_variable_list_t* fmi3_import_get_event_indicators_list(fmi3_import_t* fmu) {
@@ -478,7 +478,7 @@ int fmi3_import_get_clocked_state_dependencies(fmi3_import_t* fmu, fmi3_import_v
         numDependencies, dependsOnAll, dependencies, dependenciesKind);
 }
 
-int fmi3_import_get_variable_initial_unknown_dependencies(fmi3_import_t* fmu, fmi3_import_variable_t* variable,
+int fmi3_import_get_initial_unknown_dependencies(fmi3_import_t* fmu, fmi3_import_variable_t* variable,
         size_t* numDependencies, int* dependsOnAll, size_t** dependencies, char** dependenciesKind)
 {
     fmi3_xml_model_structure_t* ms;
@@ -486,7 +486,7 @@ int fmi3_import_get_variable_initial_unknown_dependencies(fmi3_import_t* fmu, fm
 
     ms = fmi3_xml_get_model_structure(fmu->md);
     assert(ms);
-    return fmi3_xml_get_variable_initial_unknown_dependencies(ms, variable,
+    return fmi3_xml_get_initial_unknown_dependencies(ms, variable,
         numDependencies, dependsOnAll, dependencies, dependenciesKind);
 }
 

--- a/src/XML/include/FMI3/fmi3_xml_model_structure.h
+++ b/src/XML/include/FMI3/fmi3_xml_model_structure.h
@@ -52,7 +52,7 @@ jm_vector(jm_voidp)* fmi3_xml_get_clocked_states(fmi3_xml_model_structure_t* ms)
 * @param ms A model structure pointer (returned by fmi3_xml_get_model_structure)
 * @return a variable list with all the initial unknowns in the model.
 */
-jm_vector(jm_voidp)* fmi3_xml_get_variable_initial_unknowns(fmi3_xml_model_structure_t* ms);
+jm_vector(jm_voidp)* fmi3_xml_get_initial_unknowns(fmi3_xml_model_structure_t* ms);
 
 /** \brief Get the list of all the event indicator variables in the model.
 * @param ms A model structure pointer (returned by fmi3_xml_get_model_structure)
@@ -101,7 +101,7 @@ int fmi3_xml_get_clocked_state_dependencies(fmi3_xml_model_structure_t* ms, fmi3
 
 /** \brief Get dependency information for an InitialUnknown.
  * @param ms               - A model structure pointer (returned by fmi3_xml_get_model_structure)
- * @param variable         - A model variable, e.g., from fmi3_xml_get_variable_initial_unknowns() vector.
+ * @param variable         - A model variable, e.g., from fmi3_xml_get_initial_unknowns() vector.
  * @param numDependencies  - outputs number of dependencies; 0 for no dependencies and depends on all, check 'dependsOnAll' output
  * @param dependsOnAll     - outputs 1 if a variable depends on all variables, else 0. Only relevant if numDependencies == 0
  * @param dependencies     - outputs a pointer to the dependencies (valueReferences), NULL if numDependencies == 0
@@ -109,7 +109,7 @@ int fmi3_xml_get_clocked_state_dependencies(fmi3_xml_model_structure_t* ms, fmi3
  *                           NULL if numDependencies == 0
  * @return                 - non-zero if variable cannot be found (e.g., not an InitialUnknown), invalid inputs or unexpected failures
  */
-int fmi3_xml_get_variable_initial_unknown_dependencies(fmi3_xml_model_structure_t* ms, fmi3_xml_variable_t* variable,
+int fmi3_xml_get_initial_unknown_dependencies(fmi3_xml_model_structure_t* ms, fmi3_xml_variable_t* variable,
         size_t* numDependencies, int* dependsOnAll, size_t** dependencies, char** dependenciesKind);
 
 /** \brief Get dependency information for an EventIndicator.

--- a/src/XML/src/FMI3/fmi3_xml_model_structure.c
+++ b/src/XML/src/FMI3/fmi3_xml_model_structure.c
@@ -84,7 +84,7 @@ jm_vector(jm_voidp)* fmi3_xml_get_clocked_states(fmi3_xml_model_structure_t* ms)
     return &ms->clockedStates;
 }
 
-jm_vector(jm_voidp)* fmi3_xml_get_variable_initial_unknowns(fmi3_xml_model_structure_t* ms) {
+jm_vector(jm_voidp)* fmi3_xml_get_initial_unknowns(fmi3_xml_model_structure_t* ms) {
     return &ms->initialUnknowns;
 }
 
@@ -155,7 +155,7 @@ int fmi3_xml_get_clocked_state_dependencies(fmi3_xml_model_structure_t* ms, fmi3
             numDependencies, dependsOnAll, dependencies, dependenciesKind);
 }
 
-int fmi3_xml_get_variable_initial_unknown_dependencies(fmi3_xml_model_structure_t* ms, fmi3_xml_variable_t* variable,
+int fmi3_xml_get_initial_unknown_dependencies(fmi3_xml_model_structure_t* ms, fmi3_xml_variable_t* variable,
         size_t* numDependencies, int* dependsOnAll, size_t** dependencies, char** dependenciesKind)
 {
     return fmi3_xml_get_dependencies(&(ms->initialUnknowns), ms->initialUnknownDeps, variable,


### PR DESCRIPTION
Fixup from recent renaming. It's not retrieving a property of the variable but from modelstructure.