### PR TITLE
Drop _GNU_SOURCE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -357,10 +357,6 @@ if(FMILIB_BUILD_SHARED_LIB)
     # fmiimport's dependencies such as generated code is built first.
     add_dependencies(fmilib_shared fmiimport)
 
-    if(UNIX AND NOT APPLE)
-        target_compile_definitions(fmilib_shared PRIVATE -D_GNU_SOURCE)
-    endif()
-
     # Must be PRIVATE, or tests will later inherit compile/link properties from sublibs.
     # That is incorrect, and may cause link issues.
     #

--- a/Config.cmake/jmutil.cmake
+++ b/Config.cmake/jmutil.cmake
@@ -92,8 +92,7 @@ target_include_directories(jmutils
     PUBLIC ${JMUTILS_PUBLIC_INCLUDE_DIRS}
 )
 
-if(UNIX AND NOT APPLE)
-    target_compile_definitions(jmutils PRIVATE -D_GNU_SOURCE)
-endif()
+check_function_exists("uselocale" HAVE_USELOCALE)
+target_compile_definitions(jmutils PRIVATE UNIX_THREAD_LOCALE)
 
 endif(NOT JMUTILDIR)

--- a/src/Util/src/JM/jm_portability.c
+++ b/src/Util/src/JM/jm_portability.c
@@ -19,10 +19,6 @@
 
 #include <locale.h>
 
-#if defined(_GNU_SOURCE) || defined(__APPLE__)
-#define UNIX_THREAD_LOCALE
-#endif
-
 #ifdef __APPLE__
 /* Include thread-specific locale functions for OSX. */
 #include <xlocale.h>


### PR DESCRIPTION
This seems unnecessary and makes the build fail on conda-forge with: error: expected '=', ',', ';', 'asm' or '__attribute__' before 'void':
```
2023-07-20T15:48:21.7133707Z [ 14%] Building C object CMakeFiles/jmutils.dir/src/Util/src/JM/jm_callbacks.c.o
2023-07-20T15:48:21.7304507Z In file included from /home/conda/feedstock_root/build_artifacts/omcompiler_1689867509682/work/OMCompiler/3rdParty/FMIL/src/Util/src/JM/jm_callbacks.c:16:
2023-07-20T15:48:21.7306103Z /home/conda/feedstock_root/build_artifacts/omcompiler_1689867509682/_build_env/x86_64-conda-linux-gnu/sysroot/usr/include/stdlib.h:513:14: error: expected ';' before 'void'
2023-07-20T15:48:21.7307200Z   513 | static inline void* aligned_alloc (size_t al, size_t sz)
2023-07-20T15:48:21.7307643Z       |              ^~~~~
2023-07-20T15:48:21.7307946Z       |              ;
2023-07-20T15:48:21.7459150Z make[4]: *** [CMakeFiles/jmutils.dir/build.make:76: CMakeFiles/jmutils.dir/src/Util/src/JM/jm_callbacks.c.o] Error 1
```