### PR TITLE
More error checking improvements

### DIFF
--- a/Test/FMI3/fmi3_import_arrays_test.cpp
+++ b/Test/FMI3/fmi3_import_arrays_test.cpp
@@ -389,7 +389,8 @@ static void test_array8_32_can_find_index_and_vr_of_dimensions(fmi3_import_t* xm
 
 TEST_CASE("Testing valid arrays") {
     const char* xmldir = FMI3_TEST_XML_DIR "/arrays/valid/base";
-    fmi3_import_t* xml = fmi3_testutil_parse_xml(xmldir);
+    fmi3_testutil_import_t* tfmu = fmi3_testutil_parse_xml_with_log(xmldir);
+    fmi3_import_t* xml = tfmu->fmu;
     REQUIRE(xml != nullptr);
 
     /* test valid */
@@ -408,7 +409,8 @@ TEST_CASE("Testing valid arrays") {
     test_array8_32(xml);
     test_array8_32_can_find_index_and_vr_of_dimensions(xml);
 
-    fmi3_import_free(xml);
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 0);
+    fmi3_testutil_import_free(tfmu);
 }
 
 TEST_CASE("Testing invalid array; enclosed string between doubles") {
@@ -426,6 +428,7 @@ TEST_CASE("Testing invalid array; enclosed string between doubles") {
     REQUIRE(float64Var != nullptr);
     REQUIRE(fmi3_import_get_float64_variable_start_array(float64Var) == nullptr); // since it failed to correctly parse
 
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 3); // TODO: Too many errors
     fmi3_testutil_import_free(tfmu);
 }
 
@@ -444,6 +447,7 @@ TEST_CASE("Testing invalid array; contains both doubles and string") {
     REQUIRE(float64Var != nullptr);
     REQUIRE(fmi3_import_get_float64_variable_start_array(float64Var) == nullptr); // since it failed to correctly parse
 
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 3); // Too many errors
     fmi3_testutil_import_free(tfmu);
 }
 
@@ -462,6 +466,7 @@ TEST_CASE("Testing invalid array; is string") {
     REQUIRE(float64Var != nullptr);
     REQUIRE(fmi3_import_get_float64_variable_start_array(float64Var) == nullptr); // since it failed to correctly parse
 
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 3); // TODO: Too many errors
     fmi3_testutil_import_free(tfmu);
 }
 
@@ -484,6 +489,7 @@ TEST_CASE("String array variable with too many start values") {
     REQUIRE_STREQ(startArray[1], "second");
     REQUIRE_STREQ(startArray[2], "third");
 
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 0);
     fmi3_testutil_import_free(tfmu);
 }
 
@@ -534,5 +540,7 @@ TEST_CASE("Testing defaults of array starts in case of parsing error") {
     REQUIRE(fmi3_testutil_log_contains(tfmu, "XML element 'Enumeration': could not parse value for Enumeration attribute 'start'="));
     REQUIRE(fmi3_import_get_enum_variable_start_array(fmi3_import_get_variable_as_enum(fmi3_import_get_variable_by_vr(fmu, 40))) == nullptr);
 
+    // TODO: This one gives way too many errors
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == (2+4+4+1+1)*3);
     fmi3_testutil_import_free(tfmu);
 }

--- a/Test/FMI3/fmi3_import_arrays_test.cpp
+++ b/Test/FMI3/fmi3_import_arrays_test.cpp
@@ -420,6 +420,7 @@ TEST_CASE("Testing invalid array; enclosed string between doubles") {
     REQUIRE(fmu != nullptr);
 
     REQUIRE(fmi3_testutil_log_contains(tfmu, "XML element 'Float64': could not parse value for Float64 attribute 'start'="));
+    REQUIRE(fmi3_testutil_log_contains(tfmu, "Unable to parse to Float64: x"));
     REQUIRE(fmi3_testutil_log_contains(tfmu, "Variable 'array': start value required for variables with initial == \"exact\"")); // start is required
 
     fmi3_import_variable_t* var = fmi3_import_get_variable_by_vr(fmu, 1);
@@ -428,7 +429,7 @@ TEST_CASE("Testing invalid array; enclosed string between doubles") {
     REQUIRE(float64Var != nullptr);
     REQUIRE(fmi3_import_get_float64_variable_start_array(float64Var) == nullptr); // since it failed to correctly parse
 
-    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 3); // TODO: Too many errors
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 3);
     fmi3_testutil_import_free(tfmu);
 }
 
@@ -439,6 +440,7 @@ TEST_CASE("Testing invalid array; contains both doubles and string") {
     REQUIRE(fmu != nullptr);
 
     REQUIRE(fmi3_testutil_log_contains(tfmu, "XML element 'Float64': could not parse value for Float64 attribute 'start'="));
+    REQUIRE(fmi3_testutil_log_contains(tfmu, "Unable to parse to Float64: a"));
     REQUIRE(fmi3_testutil_log_contains(tfmu, "Variable 'array': start value required for variables with initial == \"exact\"")); // start is required
 
     fmi3_import_variable_t* var = fmi3_import_get_variable_by_vr(fmu, 1);
@@ -447,7 +449,7 @@ TEST_CASE("Testing invalid array; contains both doubles and string") {
     REQUIRE(float64Var != nullptr);
     REQUIRE(fmi3_import_get_float64_variable_start_array(float64Var) == nullptr); // since it failed to correctly parse
 
-    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 3); // Too many errors
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 3);
     fmi3_testutil_import_free(tfmu);
 }
 
@@ -458,6 +460,7 @@ TEST_CASE("Testing invalid array; is string") {
     REQUIRE(fmu != nullptr);
 
     REQUIRE(fmi3_testutil_log_contains(tfmu, "XML element 'Float64': could not parse value for Float64 attribute 'start'="));
+    REQUIRE(fmi3_testutil_log_contains(tfmu, "Unable to parse to Float64: a"));
     REQUIRE(fmi3_testutil_log_contains(tfmu, "Variable 'array': start value required for variables with initial == \"exact\"")); // start is required
 
     fmi3_import_variable_t* var = fmi3_import_get_variable_by_vr(fmu, 1);
@@ -466,7 +469,7 @@ TEST_CASE("Testing invalid array; is string") {
     REQUIRE(float64Var != nullptr);
     REQUIRE(fmi3_import_get_float64_variable_start_array(float64Var) == nullptr); // since it failed to correctly parse
 
-    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 3); // TODO: Too many errors
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 3);
     fmi3_testutil_import_free(tfmu);
 }
 
@@ -540,7 +543,8 @@ TEST_CASE("Testing defaults of array starts in case of parsing error") {
     REQUIRE(fmi3_testutil_log_contains(tfmu, "XML element 'Enumeration': could not parse value for Enumeration attribute 'start'="));
     REQUIRE(fmi3_import_get_enum_variable_start_array(fmi3_import_get_variable_as_enum(fmi3_import_get_variable_by_vr(fmu, 40))) == nullptr);
 
-    // TODO: This one gives way too many errors
+    // Each error we check is also accompanied by an error giving the exact string that failed to covert to float/int/...
+    // + warning on start value being required
     REQUIRE(fmi3_testutil_get_num_problems(tfmu) == (2+4+4+1+1)*3);
     fmi3_testutil_import_free(tfmu);
 }

--- a/Test/FMI3/fmi3_import_bouncingball_xml_test.cpp
+++ b/Test/FMI3/fmi3_import_bouncingball_xml_test.cpp
@@ -316,6 +316,8 @@ static void test_parse_bouncingball(const char* xmldir, bool expectParseFailure)
 
     /* time the parsing */
     start = clock();
+    // TODO: Re-factor this one and use fmi3_testutil_get_num_problems
+    // XXX: Requires fmi3_testutil_parse_xml_with_log equivalent with annotations_callbacks support
     fmu = fmi3_import_parse_xml(context, xmldir, &annotation_callbacks);
     stop = clock();
     t = (double)(stop - start) / CLOCKS_PER_SEC;

--- a/Test/FMI3/fmi3_import_default_experiment_test.cpp
+++ b/Test/FMI3/fmi3_import_default_experiment_test.cpp
@@ -23,7 +23,8 @@
 
 TEST_CASE("Retrieving default experiment values; values defined") {
     const char* xmldir = FMI3_TEST_XML_DIR "/default_experiment/defined";
-    fmi3_import_t* xml = fmi3_testutil_parse_xml(xmldir);
+    fmi3_testutil_import_t* tfmu = fmi3_testutil_parse_xml_with_log(xmldir);
+    fmi3_import_t* xml = tfmu->fmu;
     REQUIRE(xml != nullptr);
 
     /* test defined */
@@ -38,12 +39,14 @@ TEST_CASE("Retrieving default experiment values; values defined") {
     REQUIRE(fmi3_import_get_default_experiment_tolerance(xml) == 1e-6);
     REQUIRE(fmi3_import_get_default_experiment_step_size(xml) == 2e-3);
 
-    fmi3_import_free(xml);
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 0);
+    fmi3_testutil_import_free(tfmu);
 }
 
 TEST_CASE("Retrieving default experiment values; values undefined") {
     const char* xmldir = FMI3_TEST_XML_DIR "/default_experiment/undefined";
-    fmi3_import_t* xml = fmi3_testutil_parse_xml(xmldir);
+    fmi3_testutil_import_t* tfmu = fmi3_testutil_parse_xml_with_log(xmldir);
+    fmi3_import_t* xml = tfmu->fmu;
     REQUIRE(xml != nullptr);
 
     /* test defined */
@@ -58,12 +61,20 @@ TEST_CASE("Retrieving default experiment values; values undefined") {
     REQUIRE(fmi3_import_get_default_experiment_tolerance(xml) == 1e-4);
     REQUIRE(fmi3_import_get_default_experiment_step_size(xml) == 1e-2);
 
-    fmi3_import_free(xml);
+    // These will give warnings, since attributes are not set; TODO: Is this the intended behavior?
+    REQUIRE(fmi3_testutil_log_contains(tfmu, "fmi3_xml_get_default_experiment_start: returning default value, since no attribute was defined in modelDescription"));
+    REQUIRE(fmi3_testutil_log_contains(tfmu, "fmi3_xml_get_default_experiment_stop: returning default value, since no attribute was defined in modelDescription"));
+    REQUIRE(fmi3_testutil_log_contains(tfmu, "fmi3_xml_get_default_experiment_tolerance: returning default value, since no attribute was defined in modelDescription"));
+    REQUIRE(fmi3_testutil_log_contains(tfmu, "fmi3_xml_get_default_experiment_step_size: returning default value, since no attribute was defined in modelDescription"));
+
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 4);
+    fmi3_testutil_import_free(tfmu);
 }
 
 TEST_CASE("Retrieving default experiment values; mixed defined/undefined") {
     const char* xmldir = FMI3_TEST_XML_DIR "/default_experiment/mixed";
-    fmi3_import_t* xml = fmi3_testutil_parse_xml(xmldir);
+    fmi3_testutil_import_t* tfmu = fmi3_testutil_parse_xml_with_log(xmldir);
+    fmi3_import_t* xml = tfmu->fmu;
     REQUIRE(xml != nullptr);
 
     /* test defined */
@@ -78,5 +89,10 @@ TEST_CASE("Retrieving default experiment values; mixed defined/undefined") {
     REQUIRE(fmi3_import_get_default_experiment_tolerance(xml) == 1e-6);
     REQUIRE(fmi3_import_get_default_experiment_step_size(xml) == 1e-2);
 
-    fmi3_import_free(xml);
+    // These will give warnings, since attributes are not set; TODO: Is this the intended behavior?
+    REQUIRE(fmi3_testutil_log_contains(tfmu, "fmi3_xml_get_default_experiment_stop: returning default value, since no attribute was defined in modelDescription"));
+    REQUIRE(fmi3_testutil_log_contains(tfmu, "fmi3_xml_get_default_experiment_step_size: returning default value, since no attribute was defined in modelDescription"));
+
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 2);
+    fmi3_testutil_import_free(tfmu);
 }

--- a/Test/FMI3/fmi3_import_error_handling_model_structure.cpp
+++ b/Test/FMI3/fmi3_import_error_handling_model_structure.cpp
@@ -43,8 +43,9 @@ TEST_CASE("Test missing VRs") {
     REQUIRE(fmi3_testutil_log_contains(tfmu, "Parsing XML element 'InitialUnknown': required attribute 'valueReference' not found"));
     REQUIRE(fmi3_testutil_log_contains(tfmu, "Parsing XML element 'EventIndicator': required attribute 'valueReference' not found"));
 
-    REQUIRE(fmi3_testutil_log_contains(tfmu, "Model structure is not valid due to detected errors. Cannot continue."));
+    REQUIRE(fmi3_testutil_log_contains(tfmu, "Model structure is not valid due to detected errors. Cannot continue.")); // counts as 2
 
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 7);
     fmi3_testutil_import_free(tfmu);
 }
 
@@ -60,8 +61,9 @@ TEST_CASE("Test invalid VRs") {
     REQUIRE(fmi3_testutil_log_contains(tfmu, "Failed to find variable for valueReference=4."));
     REQUIRE(fmi3_testutil_log_contains(tfmu, "Failed to find variable for valueReference=5."));
 
-    REQUIRE(fmi3_testutil_log_contains(tfmu, "Model structure is not valid due to detected errors. Cannot continue."));
+    REQUIRE(fmi3_testutil_log_contains(tfmu, "Model structure is not valid due to detected errors. Cannot continue.")); // counts as 2
 
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 7);
     fmi3_testutil_import_free(tfmu);
 }
 
@@ -175,6 +177,7 @@ TEST_CASE("Test multiple invalid dependencies") {
 
     fmi3_import_free_variable_list(varList);
 
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 5);
     fmi3_testutil_import_free(tfmu);
 }
 
@@ -201,6 +204,7 @@ TEST_CASE("Clocked States; multiple attribute issues") {
 
     fmi3_import_free_variable_list(varList);  
 
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 2);
     fmi3_testutil_import_free(tfmu);
 }
 
@@ -227,5 +231,6 @@ TEST_CASE("EventIndicators; multiple attribute issues") {
 
     fmi3_import_free_variable_list(varList);  
 
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 2);
     fmi3_testutil_import_free(tfmu);
 }

--- a/Test/FMI3/fmi3_import_fatal_test.cpp
+++ b/Test/FMI3/fmi3_import_fatal_test.cpp
@@ -30,7 +30,9 @@ TEST_CASE("Fatal error test, no VR: boolean") {
     REQUIRE(fmu == nullptr);
     
     REQUIRE(fmi3_testutil_log_contains(tfmu, "Parsing XML element 'Boolean': required attribute 'valueReference' not found"));
-    REQUIRE(fmi3_testutil_log_contains(tfmu, "Fatal failure in parsing ModelVariables. Variable(s) failed to parse or an essential error check failed."));
+    REQUIRE(fmi3_testutil_log_contains(tfmu, "Fatal failure in parsing ModelVariables. Variable(s) failed to parse or an essential error check failed.")); // counts as 2
+
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 3);
     fmi3_testutil_import_free(tfmu);
 }
 
@@ -41,7 +43,10 @@ TEST_CASE("Fatal error test, no VR: enum") {
     REQUIRE(fmu == nullptr);
     
     REQUIRE(fmi3_testutil_log_contains(tfmu, "Parsing XML element 'Enumeration': required attribute 'valueReference' not found"));
-    REQUIRE(fmi3_testutil_log_contains(tfmu, "Fatal failure in parsing ModelVariables. Variable(s) failed to parse or an essential error check failed."));
+    REQUIRE(fmi3_testutil_log_contains(tfmu, "Fatal failure in parsing ModelVariables. Variable(s) failed to parse or an essential error check failed.")); // counts as 2
+    // +1; declaredType will not be parsed
+
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 4);
     fmi3_testutil_import_free(tfmu);
 }
 
@@ -52,7 +57,9 @@ TEST_CASE("Fatal error test, no VR: float64") {
     REQUIRE(fmu == nullptr);
     
     REQUIRE(fmi3_testutil_log_contains(tfmu, "Parsing XML element 'Float64': required attribute 'valueReference' not found"));
-    REQUIRE(fmi3_testutil_log_contains(tfmu, "Fatal failure in parsing ModelVariables. Variable(s) failed to parse or an essential error check failed."));
+    REQUIRE(fmi3_testutil_log_contains(tfmu, "Fatal failure in parsing ModelVariables. Variable(s) failed to parse or an essential error check failed.")); // counts as 2
+
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 3);
     fmi3_testutil_import_free(tfmu);
 }
 
@@ -63,7 +70,9 @@ TEST_CASE("Fatal error test, no VR: int64") {
     REQUIRE(fmu == nullptr);
     
     REQUIRE(fmi3_testutil_log_contains(tfmu, "Parsing XML element 'Int64': required attribute 'valueReference' not found"));
-    REQUIRE(fmi3_testutil_log_contains(tfmu, "Fatal failure in parsing ModelVariables. Variable(s) failed to parse or an essential error check failed."));
+    REQUIRE(fmi3_testutil_log_contains(tfmu, "Fatal failure in parsing ModelVariables. Variable(s) failed to parse or an essential error check failed.")); // counts as 2
+
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 3);
     fmi3_testutil_import_free(tfmu);
 }
 
@@ -74,6 +83,8 @@ TEST_CASE("Fatal error test, no VR: string") {
     REQUIRE(fmu == nullptr);
     
     REQUIRE(fmi3_testutil_log_contains(tfmu, "Parsing XML element 'String': required attribute 'valueReference' not found"));
-    REQUIRE(fmi3_testutil_log_contains(tfmu, "Fatal failure in parsing ModelVariables. Variable(s) failed to parse or an essential error check failed."));
+    REQUIRE(fmi3_testutil_log_contains(tfmu, "Fatal failure in parsing ModelVariables. Variable(s) failed to parse or an essential error check failed.")); // counts as 2
+
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 3);
     fmi3_testutil_import_free(tfmu);
 }

--- a/Test/FMI3/fmi3_import_interface_types_test.cpp
+++ b/Test/FMI3/fmi3_import_interface_types_test.cpp
@@ -79,6 +79,8 @@ TEST_CASE("FMU interface types: Default attributes") {
         REQUIRE(fmi3_import_get_capability(fmu, fmi3_se_providesAdjointDerivatives)          == 0);
         REQUIRE(fmi3_import_get_capability(fmu, fmi3_se_providesPerElementDependencies)      == 0);
     }
+
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 0);
     fmi3_testutil_import_free(tfmu);
 }
 
@@ -141,5 +143,7 @@ TEST_CASE("FMU interface types: All attributes") {
         REQUIRE(fmi3_import_get_capability(fmu, fmi3_se_providesAdjointDerivatives)          == 1);
         REQUIRE(fmi3_import_get_capability(fmu, fmi3_se_providesPerElementDependencies)      == 1);
     }
+
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 0);
     fmi3_testutil_import_free(tfmu);
 }

--- a/Test/FMI3/fmi3_import_model_description_test.cpp
+++ b/Test/FMI3/fmi3_import_model_description_test.cpp
@@ -37,6 +37,7 @@ TEST_CASE("fmiModelDescription: FMI3 with FMI2 attribute numberOfEventIndicators
     fmi3_import_get_number_of_event_indicators(fmu, &nEvInd);
     REQUIRE(nEvInd == 0);
 
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 1);
     fmi3_testutil_import_free(tfmu);
 }
 
@@ -52,5 +53,6 @@ TEST_CASE("fmiModelDescription: Get num event indicators from ModelStructure") {
     fmi3_import_get_number_of_event_indicators(fmu, &nEvInd);
     REQUIRE(nEvInd == 2);
 
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 0);
     fmi3_testutil_import_free(tfmu);
 }

--- a/Test/FMI3/fmi3_import_model_structure_test.cpp
+++ b/Test/FMI3/fmi3_import_model_structure_test.cpp
@@ -204,8 +204,8 @@ static void test_fmi3_import_get_dependencies_invalid_api_calls(fmi3_import_t* f
 
 TEST_CASE("Valid ModelStructure parsing") {
     const char* xmldir = FMI3_TEST_XML_DIR "/model_structure/valid/basic";
-
-    fmi3_import_t* fmu = fmi3_testutil_parse_xml(xmldir);
+    fmi3_testutil_import_t* tfmu = fmi3_testutil_parse_xml_with_log(xmldir);
+    fmi3_import_t* fmu = tfmu->fmu;
     REQUIRE(fmu != nullptr);
 
     SECTION("Get Outputs") {
@@ -232,7 +232,8 @@ TEST_CASE("Valid ModelStructure parsing") {
         test_fmi3_import_get_dependencies_invalid_api_calls(fmu);
     }
     
-    fmi3_import_free(fmu);
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 0);
+    fmi3_testutil_import_free(tfmu);
 }
 
 TEST_CASE("Error check: ModelStructure; ContinuousStateDerivative missing derivative reference") {
@@ -266,6 +267,7 @@ TEST_CASE("Error check: ModelStructure; ContinuousStateDerivative missing deriva
 
     fmi3_import_free_variable_list(varList);
 
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 1);
     fmi3_testutil_import_free(tfmu);
 }
 
@@ -278,7 +280,8 @@ TEST_CASE("Error check: ModelStructure; Incorrect order of elements") {
 
     // basic Model-structure invalid, violates order requirements
     REQUIRE(fmi3_testutil_log_contains(tfmu, "'Output' cannot be placed after element 'ContinuousStateDerivative', skipping"));
-
+    // TODO: This should not be fatal, skipping means skipping
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 2);
     fmi3_testutil_import_free(tfmu);
 }
 
@@ -290,7 +293,9 @@ TEST_CASE("Warning check: ModelStructure; FMI2 style lists") {
     REQUIRE(fmu != nullptr); // Parsing is successful
 
     REQUIRE(fmi3_testutil_log_contains(tfmu, "Unknown element 'Derivatives' in XML, skipping"));
+    REQUIRE(fmi3_testutil_log_contains(tfmu, "Skipping nested XML element 'ContinuousStateDerivative'"));
 
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 2);
     fmi3_testutil_import_free(tfmu);
 }
 
@@ -312,6 +317,7 @@ TEST_CASE("Error check: ModelStructure; Output incorrect causality") {
 
     fmi3_import_free_variable_list(varList);
 
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 1);
     fmi3_testutil_import_free(tfmu);
 }
 
@@ -332,6 +338,7 @@ TEST_CASE("Error check: ModelStructure; EventIndicator variability") {
 
     fmi3_import_free_variable_list(varList);
 
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 1);
     fmi3_testutil_import_free(tfmu);
 }
 
@@ -353,6 +360,7 @@ TEST_CASE("Error check: ModelStructure; EventIndicator base type") {
 
     fmi3_import_free_variable_list(varList);
 
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 1);
     fmi3_testutil_import_free(tfmu);
 }
 
@@ -363,8 +371,9 @@ TEST_CASE("Info check: ModelStructure; EventIndicator ignored for Co-Simulation"
     fmi3_import_t* fmu = tfmu->fmu;
     REQUIRE(fmu != nullptr); // Parsing successful
 
-    REQUIRE(fmi3_testutil_log_contains(tfmu, "EventIndicator ignored since FMU kind is Co-Simulation or Scheduled Excecution."));
+    REQUIRE(fmi3_testutil_log_contains(tfmu, "EventIndicator ignored since FMU kind is Co-Simulation or Scheduled Excecution.")); // warning
 
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 1);
     fmi3_testutil_import_free(tfmu);
 }
 
@@ -385,6 +394,7 @@ TEST_CASE("Error check: ModelStructure; ClockedState without previous attribute"
 
     fmi3_import_free_variable_list(varList);
 
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 1);
     fmi3_testutil_import_free(tfmu);
 }
 
@@ -398,6 +408,7 @@ TEST_CASE("Error check: ModelStructure; ClockedState has Clock base type") {
 
     // Also tested in TEST_CASE("Invalid Clock variable - has previous")
     REQUIRE(fmi3_testutil_log_contains(tfmu, "Variables of type Clock must not have the 'previous' attribute."));
+    REQUIRE(fmi3_testutil_log_contains(tfmu, "The variable 'clock_01' is a ClockedState, but has the base type 'fmi3Clock'."));
 
     fmi3_import_variable_list_t* varList = fmi3_import_get_clocked_states_list(fmu);
     REQUIRE(fmi3_import_get_variable_list_size(varList) == 1);
@@ -408,6 +419,7 @@ TEST_CASE("Error check: ModelStructure; ClockedState has Clock base type") {
 
     fmi3_import_free_variable_list(varList);    
 
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 2);
     fmi3_testutil_import_free(tfmu);
 }
 
@@ -442,6 +454,7 @@ TEST_CASE("Error check: ModelStructure; Negative dependency value") {
     REQUIRE(fmi3_testutil_log_contains(tfmu, "'ContinuousStateDerivative': Attribute 'dependencies' contains invalid value: -1."));
     test_default_depedencies_cont_state_derivative(fmu);
 
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 1);
     fmi3_testutil_import_free(tfmu);
 }
 
@@ -455,6 +468,7 @@ TEST_CASE("Error check: ModelStructure; Invalid dependency value; not a number")
     REQUIRE(fmi3_testutil_log_contains(tfmu, "'ContinuousStateDerivative': could not parse item 0, character 'a' in the list for attribute 'dependencies'"));
     test_default_depedencies_cont_state_derivative(fmu);
 
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 1);
     fmi3_testutil_import_free(tfmu);
 }
 
@@ -468,6 +482,7 @@ TEST_CASE("Error check: ModelStructure; Mismatched number of dependencies and de
     REQUIRE(fmi3_testutil_log_contains(tfmu, "'ContinuousStateDerivative': different number of items (1 and 2) in the lists for 'dependencies' and 'dependenciesKind'"));
     test_default_depedencies_cont_state_derivative(fmu);
 
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 1);
     fmi3_testutil_import_free(tfmu);
 }
 
@@ -481,6 +496,7 @@ TEST_CASE("Error check: ModelStructure; Invalid dependenciesKind item in list") 
     REQUIRE(fmi3_testutil_log_contains(tfmu, "'ContinuousStateDerivative': could not parse item 0 in the list for attribute 'dependenciesKind'"));
     test_default_depedencies_cont_state_derivative(fmu);
 
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 1);
     fmi3_testutil_import_free(tfmu);
 }
 
@@ -494,6 +510,7 @@ TEST_CASE("Error check: ModelStructure; dependencies missing but dependenciesKin
     REQUIRE(fmi3_testutil_log_contains(tfmu, "'ContinuousStateDerivative': if `dependenciesKind` attribute is present then the `dependencies` attribute must also be present."));
     test_default_depedencies_cont_state_derivative(fmu);
 
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 1);
     fmi3_testutil_import_free(tfmu);
 }
 
@@ -537,5 +554,6 @@ TEST_CASE("Error check: ModelStructure; invalid dependenciesKind for InitialUnkn
 
     fmi3_import_free_variable_list(varList);
 
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 3);
     fmi3_testutil_import_free(tfmu);
 }

--- a/Test/FMI3/fmi3_import_model_structure_test.cpp
+++ b/Test/FMI3/fmi3_import_model_structure_test.cpp
@@ -276,12 +276,12 @@ TEST_CASE("Error check: ModelStructure; Incorrect order of elements") {
     fmi3_testutil_import_t* tfmu = fmi3_testutil_parse_xml_with_log(xmldir);
     REQUIRE(tfmu != nullptr);
     fmi3_import_t* fmu = tfmu->fmu;
-    REQUIRE(fmu == nullptr);
+    REQUIRE(fmu != nullptr);
 
     // basic Model-structure invalid, violates order requirements
     REQUIRE(fmi3_testutil_log_contains(tfmu, "'Output' cannot be placed after element 'ContinuousStateDerivative', skipping"));
-    // TODO: This should not be fatal, skipping means skipping
-    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 2);
+
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 1);
     fmi3_testutil_import_free(tfmu);
 }
 

--- a/Test/FMI3/fmi3_import_options_test.cpp
+++ b/Test/FMI3/fmi3_import_options_test.cpp
@@ -114,8 +114,6 @@ TEST_CASE("Import option testing") {
     fmi_import_context_t* context;
     fmi_version_enu_t version;
 
-    fmi3_import_t* fmu;    
-
     callbacks.malloc = malloc;
     callbacks.calloc = calloc;
     callbacks.realloc = realloc;
@@ -135,15 +133,19 @@ TEST_CASE("Import option testing") {
     version = fmi_import_get_fmi_version(context, FMU3_ME_PATH, tmpPath);
     REQUIRE(version == fmi_version_3_0_enu);
 
-    fmu = fmi3_import_parse_xml(context, tmpPath, nullptr);
+    fmi3_testutil_import_t* tfmu = fmi3_testutil_parse_xml_with_log(tmpPath);
+    fmi3_import_t* fmu = tfmu->fmu;
     REQUIRE(fmu != nullptr);
 
     /* Tests (they will exit early on failure): */
     test_option_memory_management(fmu);
-    test_loadlibrary_flag(fmu);
+    test_loadlibrary_flag(fmu); // fails
 
     /* Clean up: */
-    fmi3_import_free(fmu);
+    // TODO: Various issues related to parsing of Annotations; see sim_me_test
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 6);
+    fmi3_testutil_import_free(tfmu);
+
     fmi_import_free_context(context);
     REQUIRE(fmi_import_rmdir(&callbacks, tmpPath) == jm_status_success);
     callbacks.free((void*)tmpPath);

--- a/Test/FMI3/fmi3_import_sim_cs_test.cpp
+++ b/Test/FMI3/fmi3_import_sim_cs_test.cpp
@@ -226,7 +226,8 @@ TEST_CASE("Co-Simulation FMU example") {
     fmi_import_context_t* context = fmi_import_allocate_context(&callbacks);
     REQUIRE(fmi_import_get_fmi_version(context, FMU3_CS_PATH, tmpPath) == fmi_version_3_0_enu);
 
-    fmi3_import_t* fmu = fmi3_import_parse_xml(context, tmpPath, 0);
+    fmi3_testutil_import_t* tfmu = fmi3_testutil_parse_xml_with_log(tmpPath);
+    fmi3_import_t* fmu = tfmu->fmu;
     REQUIRE(fmu != nullptr);
     REQUIRE((fmi3_import_get_fmu_kind(fmu) & fmi3_fmu_kind_cs) == fmi3_fmu_kind_cs); // is CS FMU
 
@@ -238,7 +239,10 @@ TEST_CASE("Co-Simulation FMU example") {
     test_simulate_cs(fmu);
 
     fmi3_import_destroy_dllfmu(fmu);
-    fmi3_import_free(fmu);
+
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 0);
+    fmi3_testutil_import_free(tfmu);
+
     fmi_import_free_context(context);
     REQUIRE(fmi_import_rmdir(&callbacks, tmpPath) == jm_status_success);
     callbacks.free((void*)tmpPath);

--- a/Test/FMI3/fmi3_import_sim_me_test.cpp
+++ b/Test/FMI3/fmi3_import_sim_me_test.cpp
@@ -272,9 +272,7 @@ TEST_CASE("Model-Exchange FMU example") {
     jm_callbacks callbacks;
     fmi_import_context_t* context;
     fmi_version_enu_t version;
-    jm_status_enu_t status;
 
-    fmi3_import_t* fmu;
     const char* FMUPath = FMU3_ME_PATH;
 
     callbacks.malloc = malloc;
@@ -296,7 +294,8 @@ TEST_CASE("Model-Exchange FMU example") {
     REQUIRE(context != nullptr);
     REQUIRE(fmi_import_get_fmi_version(context, FMU3_ME_PATH, tmpPath) == fmi_version_3_0_enu);
 
-    fmu = fmi3_import_parse_xml(context, tmpPath, 0);
+    fmi3_testutil_import_t* tfmu = fmi3_testutil_parse_xml_with_log(tmpPath);
+    fmi3_import_t* fmu = tfmu->fmu;
     REQUIRE(fmu != nullptr);
 
     REQUIRE((fmi3_import_get_fmu_kind(fmu) & fmi3_fmu_kind_me) == fmi3_fmu_kind_me);
@@ -307,7 +306,11 @@ TEST_CASE("Model-Exchange FMU example") {
     test_simulate_me(fmu);
 
     fmi3_import_destroy_dllfmu(fmu);
-    fmi3_import_free(fmu);
+
+    // TODO: Various issues related to parsing of Annotations
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 5);
+    fmi3_testutil_import_free(tfmu);
+
     fmi_import_free_context(context);
     REQUIRE(fmi_import_rmdir(&callbacks, tmpPath) == jm_status_success);
     callbacks.free((void*)tmpPath);

--- a/Test/FMI3/fmi3_import_sim_se_test.cpp
+++ b/Test/FMI3/fmi3_import_sim_se_test.cpp
@@ -141,9 +141,6 @@ TEST_CASE("main") {
     jm_callbacks callbacks;
     fmi_import_context_t* context;
     fmi_version_enu_t version;
-    jm_status_enu_t status;
-
-    fmi3_import_t* fmu;
 
     callbacks.malloc = malloc;
     callbacks.calloc = calloc;
@@ -164,7 +161,8 @@ TEST_CASE("main") {
     REQUIRE(context != nullptr);
     REQUIRE(fmi_import_get_fmi_version(context, FMU3_SE_PATH, tmpPath) == fmi_version_3_0_enu);
 
-    fmu = fmi3_import_parse_xml(context, tmpPath, 0);
+    fmi3_testutil_import_t* tfmu = fmi3_testutil_parse_xml_with_log(tmpPath);
+    fmi3_import_t* fmu = tfmu->fmu;
     REQUIRE(fmu != nullptr);
 
     REQUIRE((fmi3_import_get_fmu_kind(fmu) & fmi3_fmu_kind_se) == fmi3_fmu_kind_se);
@@ -178,7 +176,10 @@ TEST_CASE("main") {
     /* TODO: add simulation */
 
     fmi3_import_destroy_dllfmu(fmu);
-    fmi3_import_free(fmu);
+
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 0);
+    fmi3_testutil_import_free(tfmu);
+
     fmi_import_free_context(context);
     REQUIRE(fmi_import_rmdir(&callbacks, tmpPath) == jm_status_success);
     callbacks.free((void*)tmpPath);

--- a/Test/FMI3/fmi3_import_start_arrays_test.cpp
+++ b/Test/FMI3/fmi3_import_start_arrays_test.cpp
@@ -76,7 +76,8 @@ static fmi3_import_dimension_list_t* basic_array_checks(fmi3_import_variable_t* 
 
 TEST_CASE("Binary array") {
     const char* xmldir = FMI3_TEST_XML_DIR "/arrays/valid/binary_array";
-    fmi3_import_t* xml = fmi3_testutil_parse_xml(xmldir);
+    fmi3_testutil_import_t* tfmu = fmi3_testutil_parse_xml_with_log(xmldir);
+    fmi3_import_t* xml = tfmu->fmu;
     REQUIRE(xml != nullptr);
 
     SECTION("Test binary start array") {
@@ -109,24 +110,16 @@ TEST_CASE("Binary array") {
         REQUIRE(sizes[1]   == 2);
         REQUIRE(sizes[2]   == 2);
     }
-    fmi3_import_free(xml);
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 0);
+    fmi3_testutil_import_free(tfmu);
 }
 
 TEST_CASE("Test array parsing and verify retrieved start values are as expected"){
-    jm_callbacks cb;
-    fmi_import_context_t *context;
+    const char* xmldir = FMI3_TEST_XML_DIR "/arrays/valid/base";
+    fmi3_testutil_import_t* tfmu = fmi3_testutil_parse_xml_with_log(xmldir);
+    fmi3_import_t* xml = tfmu->fmu;
+    REQUIRE(xml != nullptr);
 
-    cb.malloc    = malloc;
-    cb.calloc    = calloc;
-    cb.realloc   = realloc;
-    cb.free      = free;
-    cb.logger    = importlogger;
-    cb.log_level = jm_log_level_all;
-    cb.context   = NULL;
-    context = fmi_import_allocate_context(&cb);
-    const char* xmlPath = FMI3_TEST_XML_DIR "/arrays/valid/base";
-
-    fmi3_import_t *xml = parse_xml(xmlPath);
     SECTION("Test boolean start array") {
         REQUIRE(xml != nullptr);
         fmi3_import_variable_t* v = fmi3_import_get_variable_by_name(xml, "bool_array");
@@ -274,13 +267,14 @@ TEST_CASE("Test array parsing and verify retrieved start values are as expected"
         fmi3_string_t start = fmi3_import_get_string_variable_start(fmi3_import_get_variable_as_string(v));
         REQUIRE(strcmp(start, "A sTring value") == 0);
     }
-    fmi_import_free_context(context);
-    fmi3_import_free(xml);
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 0);
+    fmi3_testutil_import_free(tfmu);
 }
 
 TEST_CASE("Test int64 start array with 100 variables") {
     const char* xmldir = FMI3_TEST_XML_DIR "/arrays/valid/big1";
-    fmi3_import_t* xml = fmi3_testutil_parse_xml(xmldir);
+    fmi3_testutil_import_t* tfmu = fmi3_testutil_parse_xml_with_log(xmldir);
+    fmi3_import_t* xml = tfmu->fmu;
     REQUIRE(xml != nullptr);
 
     fmi3_import_variable_t* v = fmi3_import_get_variable_by_name(xml, "int64_array_100");
@@ -293,5 +287,7 @@ TEST_CASE("Test int64 start array with 100 variables") {
         expected_value = (i%5 == 0) ? -i : i;
         REQUIRE(start[i-1] == expected_value);
     }
-    fmi3_import_free(xml);
+    
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 0);
+    fmi3_testutil_import_free(tfmu);
 }

--- a/Test/FMI3/fmi3_import_terminals_and_icons_test.cpp
+++ b/Test/FMI3/fmi3_import_terminals_and_icons_test.cpp
@@ -23,7 +23,8 @@
 
 TEST_CASE("Test parse terminals and icons") {
     const char* xmldir = FMI3_TEST_XML_DIR "/terminals_and_icons/valid/basic";
-    fmi3_import_t* xml = fmi3_testutil_parse_xml(xmldir);
+    fmi3_testutil_import_t* tfmu = fmi3_testutil_parse_xml_with_log(xmldir);
+    fmi3_import_t* xml = tfmu->fmu;
     REQUIRE(xml != nullptr);
     REQUIRE(fmi3_import_get_has_terminals_and_icons(xml) != 0);
 
@@ -56,7 +57,9 @@ TEST_CASE("Test parse terminals and icons") {
         REQUIRE(fmi3_import_get_terminal_name(nullptr) == nullptr);
     }
 
-    fmi3_import_free(xml);
+    // TODO: Current example xml includes elements/attributes not yet parsed
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 11); 
+    fmi3_testutil_import_free(tfmu);
 }
 
 TEST_CASE("No terminalsAndIcons.xml, test log message") {
@@ -68,6 +71,7 @@ TEST_CASE("No terminalsAndIcons.xml, test log message") {
     REQUIRE(fmi3_import_get_has_terminals_and_icons(fmu) == 0); // failed parse of terminalsAndIcons
 
     REQUIRE(fmi3_testutil_log_contains(tfmu, "[INFO][FMI3XML] Could not find or open terminalsAndIcons.xml:"));
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 0);
     fmi3_testutil_import_free(tfmu);
 }
 
@@ -79,7 +83,9 @@ TEST_CASE("Error check; Mismatching fmiVersions of modelDescription.xml and term
     REQUIRE(fmi3_import_get_has_terminals_and_icons(fmu) == 0); // failed parse of terminalsAndIcons
 
     const char* logMsg = "Mismatch of attribute 'fmiVersion' in modelDescription.xml: '3.0-alpha' and terminalsAndIcons.xml: '3.0-beta'.";
-    REQUIRE(fmi3_testutil_log_contains(tfmu, logMsg));
+    REQUIRE(fmi3_testutil_log_contains(tfmu, logMsg)); // fatal, counts as 2
+
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 2);
     fmi3_testutil_import_free(tfmu);
 }
 
@@ -91,7 +97,9 @@ TEST_CASE("Error check; Terminals with duplicate names") {
     REQUIRE(fmi3_import_get_has_terminals_and_icons(fmu) == 0); // failed parse of terminalsAndIcons
 
     const char* logMsg = "Two terminals with the same name 'terminalA' found. This is not allowed by the specification.";
-    REQUIRE(fmi3_testutil_log_contains(tfmu, logMsg));
+    REQUIRE(fmi3_testutil_log_contains(tfmu, logMsg)); // fatal, counts as 2
+
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 2);
     fmi3_testutil_import_free(tfmu);
 }
 
@@ -103,6 +111,8 @@ TEST_CASE("Error check; Terminals with duplicate names; edge case of empty name"
     REQUIRE(fmi3_import_get_has_terminals_and_icons(fmu) == 0); // failed parse of terminalsAndIcons
 
     const char* logMsg = "Two terminals with the same name '' found. This is not allowed by the specification.";
-    REQUIRE(fmi3_testutil_log_contains(tfmu, logMsg));
+    REQUIRE(fmi3_testutil_log_contains(tfmu, logMsg)); // fatal, counts as 2
+
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 2);
     fmi3_testutil_import_free(tfmu);
 }

--- a/Test/FMI3/fmi3_import_unit_definitions_test.cpp
+++ b/Test/FMI3/fmi3_import_unit_definitions_test.cpp
@@ -315,8 +315,8 @@ static void test_float32(fmi3_import_t* xml) {
 
 TEST_CASE("Unit and DisplayUnit testing") {
     const char* xmldir = FMI3_TEST_XML_DIR "/unit_display_unit/valid";
-
-    fmi3_import_t* xml = fmi3_testutil_parse_xml(xmldir);
+    fmi3_testutil_import_t* tfmu = fmi3_testutil_parse_xml_with_log(xmldir);
+    fmi3_import_t* xml = tfmu->fmu;
     REQUIRE(xml != nullptr);
 
     SECTION("Basic Unit verification") {
@@ -331,7 +331,8 @@ TEST_CASE("Unit and DisplayUnit testing") {
         test_float32(xml);
     }
 
-    fmi3_import_free(xml);   
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 0);
+    fmi3_testutil_import_free(tfmu);
 }
 
 TEST_CASE("Invalid DisplayUnit - inserve = true  + non-zero offset") {
@@ -341,6 +342,8 @@ TEST_CASE("Invalid DisplayUnit - inserve = true  + non-zero offset") {
     REQUIRE(fmu != nullptr);
     
     REQUIRE(fmi3_testutil_log_contains(tfmu, "DisplayUnit attribute 'inverse' = true only allowed for 'offset' = 0"));
+
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 1);
     fmi3_testutil_import_free(tfmu);
 }
 
@@ -351,5 +354,7 @@ TEST_CASE("Invalid DisplayUnit - zero factor") {
     REQUIRE(fmu != nullptr);
     
     REQUIRE(fmi3_testutil_log_contains(tfmu, "DisplayUnit attribute 'factor' cannot be equal to zero"));
+
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 1);
     fmi3_testutil_import_free(tfmu);
 }

--- a/Test/FMI3/fmi3_import_variable_test.cpp
+++ b/Test/FMI3/fmi3_import_variable_test.cpp
@@ -348,9 +348,13 @@ TEST_CASE("Invalid Clock variable - no intervalVariability attr") {
     fmi3_testutil_import_t* tfmu = fmi3_testutil_parse_xml_with_log(xmldir);
     REQUIRE(tfmu != nullptr);
     fmi3_import_t* fmu = tfmu->fmu;
-    REQUIRE(fmu == nullptr);
+    REQUIRE(fmu != nullptr);
 
-    REQUIRE(fmi3_testutil_log_contains(tfmu, "Parsing XML element 'Clock': required attribute 'intervalVariability' not found"));
+    fmi3_import_variable_t* var = fmi3_import_get_variable_by_vr(fmu, 1);
+    REQUIRE(var != nullptr);
+    fmi3_import_clock_variable_t* clockVar = fmi3_import_get_variable_as_clock(var);
+    REQUIRE(clockVar != nullptr);
+    REQUIRE(fmi3_import_get_clock_variable_interval_variability(clockVar) == fmi3_interval_variability_unknown);
 
     fmi3_testutil_import_free(tfmu);
 }
@@ -863,11 +867,16 @@ TEST_CASE("Invalid; clock without intervalVariability") {
 
     fmi3_testutil_import_t* tfmu = fmi3_testutil_parse_xml_with_log(xmldir);
     REQUIRE(tfmu != nullptr);
-    REQUIRE(tfmu->fmu == nullptr);
+    fmi3_import_t* fmu = tfmu->fmu;
+    REQUIRE(fmu != nullptr);
 
     REQUIRE(fmi3_testutil_log_contains(tfmu, "Parsing XML element 'Clock': required attribute 'intervalVariability' not found"));
 
-    REQUIRE(fmi3_testutil_log_contains(tfmu, "Fatal failure in parsing ModelVariables. Variable(s) failed to parse or an essential error check failed."));
+    fmi3_import_variable_t* var = fmi3_import_get_variable_by_vr(fmu, 1);
+    REQUIRE(var != nullptr);
+    fmi3_import_clock_variable_t* clockVar = fmi3_import_get_variable_as_clock(var);
+    REQUIRE(clockVar != nullptr);
+    REQUIRE(fmi3_import_get_clock_variable_interval_variability(clockVar) == fmi3_interval_variability_unknown);
 
     fmi3_testutil_import_free(tfmu);
 }

--- a/Test/FMI3/fmi3_import_variable_types_test.cpp
+++ b/Test/FMI3/fmi3_import_variable_types_test.cpp
@@ -112,20 +112,16 @@ static void test_full_float_32(fmi3_import_t* xml) {
 
 TEST_CASE("Varibles types testing") {
     const char* xmldir = FMI3_TEST_XML_DIR "/variable_types/float";
+    fmi3_testutil_import_t* tfmu = fmi3_testutil_parse_xml_with_log(xmldir);
+    fmi3_import_t* fmu = tfmu->fmu;
+    REQUIRE(fmu != nullptr);
 
-    jm_callbacks* cb = jm_get_default_callbacks();
-    fmi_import_context_t* ctx = fmi_import_allocate_context(cb);
-    fmi3_import_t* xml = fmi3_import_parse_xml(ctx, xmldir, nullptr);
+    test_small_float64(fmu);
+    test_small_float32(fmu);
 
-    REQUIRE(ctx != nullptr);
-    REQUIRE(xml != nullptr);
+    test_full_float64(fmu);
+    test_full_float_32(fmu);
 
-    test_small_float64(xml);
-    test_small_float32(xml);
-
-    test_full_float64(xml);
-    test_full_float_32(xml);
-
-    fmi_import_free_context(ctx);
-    fmi3_import_free(xml);
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 0);
+    fmi3_testutil_import_free(tfmu);
 }

--- a/Test/FMI3/fmi3_variability_causality_initial_test.cpp
+++ b/Test/FMI3/fmi3_variability_causality_initial_test.cpp
@@ -335,6 +335,7 @@ TEST_CASE("Error check bad variability causality combination fallback") {
     v = fmi3_import_get_variable_by_vr(tfmu->fmu, 21);
     REQUIRE(fmi3_import_get_variable_variability(v) == fmi3_variability_enu_discrete);
 
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 6);
     fmi3_testutil_import_free(tfmu);
 }
 
@@ -392,6 +393,9 @@ TEST_CASE("Test default variabilities") {
         v = fmi3_import_get_variable_by_vr(tfmu->fmu, 17);
         REQUIRE(fmi3_import_get_variable_variability(v) == fmi3_variability_enu_continuous);
     }
+
+    // Taking default does not have any warnings or similar
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 0);
     fmi3_testutil_import_free(tfmu);
 }
 
@@ -411,5 +415,6 @@ TEST_CASE("Test missing start values") {
     REQUIRE(fmi3_testutil_log_contains(tfmu, "Variable 'f64_exact': start value required for variables with initial == \"exact\""));
     REQUIRE(fmi3_testutil_log_contains(tfmu, "Variable 'f64_approx': start value required for variables with initial == \"approx\""));
 
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 6);
     fmi3_testutil_import_free(tfmu);
 }

--- a/Test/FMI3/fmi3_xml_locale_test.cpp
+++ b/Test/FMI3/fmi3_xml_locale_test.cpp
@@ -86,8 +86,7 @@ TEST_CASE("Test parsing with locale set") {
          * the result. */
 
         const char* xmldir = FMI3_TEST_XML_DIR "/env/locale";
-        
-        fmi3_testutil_import_t* tfmu = fmi3_testutil_parse_xml_with_log(xml_dir);
+        fmi3_testutil_import_t* tfmu = fmi3_testutil_parse_xml_with_log(xmldir);
         fmi3_import_t* xml = tfmu->fmu;
         REQUIRE(xml != nullptr);
 

--- a/Test/FMI3/fmi3_xml_locale_test.cpp
+++ b/Test/FMI3/fmi3_xml_locale_test.cpp
@@ -87,7 +87,8 @@ TEST_CASE("Test parsing with locale set") {
 
         const char* xmldir = FMI3_TEST_XML_DIR "/env/locale";
         
-        fmi3_import_t* xml = fmi3_testutil_parse_xml(xmldir);
+        fmi3_testutil_import_t* tfmu = fmi3_testutil_parse_xml_with_log(xml_dir);
+        fmi3_import_t* xml = tfmu->fmu;
         REQUIRE(xml != nullptr);
 
         /* If the decimal delimiter is comma, sscanf will only parse
@@ -95,9 +96,10 @@ TEST_CASE("Test parsing with locale set") {
         REQUIRE(fmi3_import_get_default_experiment_start(xml)     == 2.3 );
         REQUIRE(fmi3_import_get_default_experiment_stop(xml)      == 3.55);
         REQUIRE(fmi3_import_get_default_experiment_tolerance(xml) == 1e-6);
-        REQUIRE(fmi3_import_get_default_experiment_step_size(xml)      == 2e-3);
+        REQUIRE(fmi3_import_get_default_experiment_step_size(xml) == 2e-3);
 
-        fmi3_import_free(xml);
+        REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 0);
+        fmi3_testutil_import_free(tfmu);
     }
 
     /* Cleanup and verify that locale is properly restored.

--- a/Test/FMI3/fmi3_xml_naming_conv_test.cpp
+++ b/Test/FMI3/fmi3_xml_naming_conv_test.cpp
@@ -23,20 +23,24 @@
 #include "catch.hpp"
 
 void parse_exclude_msg(const char* xml_dir, const char* log_msg) {
+    INFO("Testing " << xml_dir);
     fmi3_testutil_import_t* tfmu = fmi3_testutil_parse_xml_with_log(xml_dir);
     fmi3_import_t* fmu = tfmu->fmu;
     REQUIRE(fmu != nullptr);
     
     REQUIRE(!fmi3_testutil_log_contains(tfmu, log_msg));
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 0);
     fmi3_testutil_import_free(tfmu);
 }
 
 void parse_include_msg(const char* xml_dir, const char* log_msg) {
+    INFO("Testing " << xml_dir);
     fmi3_testutil_import_t* tfmu = fmi3_testutil_parse_xml_with_log(xml_dir);
     fmi3_import_t* fmu = tfmu->fmu;
     REQUIRE(fmu != nullptr);
     
     REQUIRE(fmi3_testutil_log_contains(tfmu, log_msg));
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 1);
     fmi3_testutil_import_free(tfmu);
 }
 

--- a/Test/FMI3/fmu_dummy/fmu3_model.c
+++ b/Test/FMI3/fmu_dummy/fmu3_model.c
@@ -46,16 +46,16 @@ static int calc_initialize(instance_ptr_t inst)
 
         inst->cb.logMessage(inst->cb.instanceEnvironment, fmi3OK, "INFO", "###### Initializing instance ######");
 
-        snprintf(msg, msg_sz, "Init #r%d#=%g", VAR_R_HEIGHT, inst->states[VAR_R_HEIGHT]);
+        snprintf(msg, msg_sz, "Init #%d#=%g", VAR_R_HEIGHT, inst->states[VAR_R_HEIGHT]);
         inst->cb.logMessage(inst->cb.instanceEnvironment, fmi3OK, "INFO", msg);
 
-        snprintf(msg, msg_sz, "Init #r%d#=%g", VAR_R_HEIGHT, "Init #r%d#=%g",VAR_R_HEIGHT_SPEED, inst->states[VAR_R_HEIGHT_SPEED]);
+        snprintf(msg, msg_sz, "Init #%d#=%g", VAR_R_HEIGHT, "Init #%d#=%g",VAR_R_HEIGHT_SPEED, inst->states[VAR_R_HEIGHT_SPEED]);
         inst->cb.logMessage(inst->cb.instanceEnvironment, fmi3OK, "INFO", msg);
 
-        snprintf(msg, msg_sz, "Init #r%d#=%g", VAR_R_HEIGHT, "Init #r%d#=%g",VAR_R_HEIGHT_SPEED, "Init #r%d#=%g",VAR_R_GRATIVY, inst->reals[VAR_R_GRATIVY]);
+        snprintf(msg, msg_sz, "Init #%d#=%g", VAR_R_HEIGHT, "Init #%d#=%g",VAR_R_HEIGHT_SPEED, "Init #%d#=%g",VAR_R_GRATIVY, inst->reals[VAR_R_GRATIVY]);
         inst->cb.logMessage(inst->cb.instanceEnvironment, fmi3OK, "INFO", msg);
 
-        snprintf(msg, msg_sz, "Init #r%d#=%g", VAR_R_HEIGHT, "Init #r%d#=%g",VAR_R_HEIGHT_SPEED, "Init #r%d#=%g",VAR_R_BOUNCE_CONF, inst->reals[VAR_R_BOUNCE_CONF]);
+        snprintf(msg, msg_sz, "Init #%d#=%g", VAR_R_HEIGHT, "Init #%d#=%g",VAR_R_HEIGHT_SPEED, "Init #%d#=%g",VAR_R_BOUNCE_CONF, inst->reals[VAR_R_BOUNCE_CONF]);
         inst->cb.logMessage(inst->cb.instanceEnvironment, fmi3OK, "INFO", msg);
     }
     return 0;

--- a/Test/FMI3/fmu_dummy/modelDescription_me.xml
+++ b/Test/FMI3/fmu_dummy/modelDescription_me.xml
@@ -9,20 +9,15 @@
   <TypeDefinitions>
       <Float64Type name="Modelica.Blocks.Interfaces.RealOutput" />
   </TypeDefinitions>
-  <VendorAnnotations>
-    <Tool name ="JModelica">
-      <JModelica name="model annotations">Test data</JModelica>
-    </Tool>
-  </VendorAnnotations>
 <ModelVariables>
   <Float64 name="HEIGHT" valueReference="0" initial="exact" causality="output" description="Height of the ball" start="1.0" reinit="true" />
   <Float64 name="HEIGHT_SPEED" valueReference="1" initial="exact" description="Speed of the ball" start="4.0" derivative="0" reinit="true">
-    <Alias name="HEIGHT_SPEED alias" description="Velocity of the ball"/>
     <Annotations>
       <Tool name ="JModelica">
         <JModelica name="HEIGHT_SPEED variable annotations">Test data</JModelica>
       </Tool>
     </Annotations>
+    <Alias name="HEIGHT_SPEED alias" description="Velocity of the ball"/>
   </Float64>
   <Float64 name="HEIGHT_ACC" valueReference="2" description="Acceleration of the ball" derivative="1" />
   <Float64 name="GRAVITY" valueReference="3" description="Gravity constant" initial="exact" start="-9.81"/>
@@ -41,10 +36,17 @@
   </Float64>
   <Float64 name="event_indicator_1" valueReference="17" description="HEIGHT &lt; 0"/>
 </ModelVariables>
+
 <ModelStructure>
   <Output valueReference="0"/>
   <ContinuousStateDerivative valueReference="1"/>
   <ContinuousStateDerivative valueReference="2" dependencies="3" dependenciesKind="constant"/>
   <EventIndicator valueReference="17" dependencies="0" dependenciesKind="constant"/>
 </ModelStructure>
+
+<Annotations>
+  <Tool name ="JModelica">
+    <JModelica name="model annotations">Test data</JModelica>
+  </Tool>
+</Annotations>
 </fmiModelDescription>

--- a/Test/FMI3/fmu_dummy/modelDescription_se.xml
+++ b/Test/FMI3/fmu_dummy/modelDescription_se.xml
@@ -5,10 +5,8 @@
   generationTool="None"
   description="A bouncing ball model"
   instantiationToken="123">
-  <ScheduledExecution
-  modelIdentifier="BouncingBall3"
-  canHandleVariableCommunicationStepSize="true"
-  />
+  <ScheduledExecution modelIdentifier="BouncingBall3"/>
+
 <ModelVariables>
   <Float64 name="HEIGHT" valueReference="0" initial="exact" causality="output" description="Height of the ball" start="1.0"/>
   <Float64 name="HEIGHT_SPEED" valueReference="1" initial="exact" description="Velocity of the ball" start="4.0">

--- a/Test/FMI3/parser_test_xmls/error_handling/model_variables/global_error_checks/modelDescription.xml
+++ b/Test/FMI3/parser_test_xmls/error_handling/model_variables/global_error_checks/modelDescription.xml
@@ -18,7 +18,7 @@
 
   <!-- Invalid previous reference -->
   <Float64 name="clocked_var_previous" valueReference="10" variability="discrete"/>
-  <Float64 valueReference="11" name="float_prev" previous="1000" clocks="12"/>
+  <Float64 valueReference="11" name="float_prev" previous="1000" clocks="12" variability="discrete"/>
   <Clock name="clock" valueReference="12" intervalVariability="constant"/>
 </ModelVariables>
 

--- a/Test/FMI3/parser_test_xmls/error_handling/model_variables/invalid_reference_resolve/modelDescription.xml
+++ b/Test/FMI3/parser_test_xmls/error_handling/model_variables/invalid_reference_resolve/modelDescription.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fmiModelDescription fmiVersion="3.0" modelName="" instantiationToken="">
+<ModelExchange modelIdentifier="id_me"/>
+
+<ModelVariables>
+  <Float64 valueReference="0"/> <!-- missing name, invalid variable -->
+
+  <Float64 name="f1" valueReference="1" derivative="0"/>
+  <Float64 name="f2" valueReference="2" clocks="3" previous="0" variability="discrete"/>
+  <Clock   name="c"  valueReference="3" intervalVariability="constant"/>
+</ModelVariables>
+
+<ModelStructure/>
+</fmiModelDescription>

--- a/Test/FMI3/parser_test_xmls/model_structure/invalid/incorrect_order/modelDescription.xml
+++ b/Test/FMI3/parser_test_xmls/model_structure/invalid/incorrect_order/modelDescription.xml
@@ -10,6 +10,6 @@
 
 <ModelStructure>
   <ContinuousStateDerivative valueReference="1"/>
-  <Output valueReference="2"> <!-- Invalid: ModelStructure requires an ordered list; all 'Output' must be before 'ContinuousStateDerivative' -->
+  <Output valueReference="2"/> <!-- Invalid: ModelStructure requires an ordered list; all 'Output' must be before 'ContinuousStateDerivative' -->
 </ModelStructure>
 </fmiModelDescription>

--- a/Test/FMI3/parser_test_xmls/variability_causality_initial/invalid/bad_variability_causality_fallback/modelDescription.xml
+++ b/Test/FMI3/parser_test_xmls/variability_causality_initial/invalid/bad_variability_causality_fallback/modelDescription.xml
@@ -4,13 +4,13 @@
 
 <ModelVariables>
 	<!-- test various invalid causility & variablity combinations for their errors and fallbacks -->
-	<Float32 name="f32_parameter" valueReference="0" causality="parameter" variability="continuous"/>
+	<Float32 name="f32_parameter" valueReference="0" causality="parameter" variability="continuous" start="0"/>
 	<Float32 name="f32_non_parameter" valueReference="1" causality="output" variability="fixed"/>
 
-	<Float64 name="f64_parameter" valueReference="10" causality="parameter" variability="continuous"/>
+	<Float64 name="f64_parameter" valueReference="10" causality="parameter" variability="continuous" start="0"/>
 	<Float64 name="f64_non_parameter" valueReference="11" causality="output" variability="fixed"/>
 
-	<Int64 name="i64_parameter" valueReference="20" causality="parameter" variability="continuous"/>
+	<Int64 name="i64_parameter" valueReference="20" causality="parameter" variability="continuous" start="0"/>
 	<Int64 name="i64_non_parameter" valueReference="21" causality="output" variability="fixed"/>
 </ModelVariables>
 

--- a/Test/FMI3/parser_test_xmls/variables/invalid/intermediateUpdate_parameter/modelDescription.xml
+++ b/Test/FMI3/parser_test_xmls/variables/invalid/intermediateUpdate_parameter/modelDescription.xml
@@ -4,7 +4,7 @@
 
 <ModelVariables>
     <!-- Variables with causality='parameter' must not be marked with intermediateUpdate='true' -->
-    <Float64 name="var" valueReference="0" causality="parameter" intermediateUpdate="true"/> 
+    <Float64 name="var" valueReference="0" causality="parameter" intermediateUpdate="true" start="0"/> 
 </ModelVariables>
 
 <ModelStructure/>

--- a/Test/FMI3/parser_test_xmls/variables/valid/basic1/modelDescription.xml
+++ b/Test/FMI3/parser_test_xmls/variables/valid/basic1/modelDescription.xml
@@ -56,7 +56,7 @@
   =================================================================================== -->
 
     <!-- Variable with non-default canHandleMultipleSetPerTimeInstant -->
-  <Float64 name="cannotHandle" valueReference="20" causality="input" canHandleMultipleSetPerTimeInstant="false" />
+  <Float64 name="cannotHandle" valueReference="20" causality="input" canHandleMultipleSetPerTimeInstant="false" start="0"/>
 
   <!-- Binary with empty mimeType-->
   <Binary name="binaryEmptyMimeType" valueReference="998" mimeType=""/>

--- a/src/Import/src/FMI/fmi_import_context.c
+++ b/src/Import/src/FMI/fmi_import_context.c
@@ -26,7 +26,7 @@
 #define MODULE "FMILIB"
 
 fmi_import_context_t* fmi_import_allocate_context(jm_callbacks* callbacks) {
-    jm_log_verbose(callbacks, MODULE, "Allocating FMIL context");
+    if (callbacks) {jm_log_verbose(callbacks, MODULE, "Allocating FMIL context");}
     return fmi_xml_allocate_context(callbacks);
 }
 

--- a/src/Util/src/JM/jm_portability.c
+++ b/src/Util/src/JM/jm_portability.c
@@ -199,15 +199,15 @@ jm_status_enu_t jm_mkdir(jm_callbacks* cb, const char* dir) {
 
 
 jm_status_enu_t jm_rmdir(jm_callbacks* cb, const char* dir) {
+    if(!cb) {
+        cb = jm_get_default_callbacks();
+    }
 #ifdef WIN32
     const char* fmt_cmd = "rmdir /s /q %s";
 #else
     const char* fmt_cmd = "rm -rf %s";
 #endif
     char * buf = (char*)cb->calloc(sizeof(char), strlen(dir)+strlen(fmt_cmd)+1);
-    if(!cb) {
-        cb = jm_get_default_callbacks();
-    }
     if(!buf) {
         jm_log_error(cb,module,"Could not allocate memory");
         return jm_status_error;

--- a/src/Util/src/JM/jm_portability.c
+++ b/src/Util/src/JM/jm_portability.c
@@ -199,7 +199,8 @@ jm_status_enu_t jm_mkdir(jm_callbacks* cb, const char* dir) {
 
 
 jm_status_enu_t jm_rmdir(jm_callbacks* cb, const char* dir) {
-    if(!cb) {
+    if (!cb) {
+
         cb = jm_get_default_callbacks();
     }
 #ifdef WIN32

--- a/src/XML/src/FMI/fmi_xml_context.c
+++ b/src/XML/src/FMI/fmi_xml_context.c
@@ -25,7 +25,7 @@ fmi_xml_context_t* fmi_xml_allocate_context(jm_callbacks* callbacks) {
     jm_callbacks* cb;
     fmi_xml_context_t* c;
 
-    if(callbacks) {
+    if (callbacks) {
         cb = callbacks;
     } else {
         cb = jm_get_default_callbacks();
@@ -33,7 +33,7 @@ fmi_xml_context_t* fmi_xml_allocate_context(jm_callbacks* callbacks) {
     jm_log_debug(callbacks, MODULE, "Allocating context for XML parsing module");
 
     c = cb->malloc(sizeof(fmi_xml_context_t));
-    if(!c) {
+    if (!c) {
         jm_log_fatal(callbacks, MODULE, "Could not allocate memory");
         return 0;
     }

--- a/src/XML/src/FMI/fmi_xml_context.c
+++ b/src/XML/src/FMI/fmi_xml_context.c
@@ -21,28 +21,27 @@
 
 static char* MODULE="FMIXML";
 
-fmi_xml_context_t* fmi_xml_allocate_context( jm_callbacks* callbacks) {
+fmi_xml_context_t* fmi_xml_allocate_context(jm_callbacks* callbacks) {
     jm_callbacks* cb;
     fmi_xml_context_t* c;
 
-    jm_log_debug(callbacks, MODULE, "Allocating context for XML parsing module");
-
     if(callbacks) {
         cb = callbacks;
-    }
-    else {
+    } else {
         cb = jm_get_default_callbacks();
     }
+    jm_log_debug(callbacks, MODULE, "Allocating context for XML parsing module");
+
     c = cb->malloc(sizeof(fmi_xml_context_t));
     if(!c) {
         jm_log_fatal(callbacks, MODULE, "Could not allocate memory");
         return 0;
     }
-    c->callbacks = callbacks;
+    c->callbacks = cb;
     c->parser = 0;
     c->fmi_version = fmi_version_unknown_enu;
     c->configuration = 0;
-    jm_log_debug(callbacks, MODULE, "Returning allocated context");
+    jm_log_debug(c->callbacks, MODULE, "Returning allocated context");
     return c;
 }
 

--- a/src/XML/src/FMI3/fmi3_xml_type.c
+++ b/src/XML/src/FMI3/fmi3_xml_type.c
@@ -1113,7 +1113,7 @@ fmi3_xml_clock_type_props_t* fmi3_xml_parse_clock_type_properties(fmi3_xml_parse
     int ret = fmi3_xml_parse_attr_as_enum(context, elmID, fmi_attr_id_intervalVariability, 1 /*required*/,
             &props->intervalVariability, fallbackProps->intervalVariability, intervalVariabilityMap);
     if (ret) {
-        // Note: Eventhough this attribute is required, this does not break the API
+        // Note: Even though this attribute is required, this does not break the API (by design)
         // accept it anyways
         props->intervalVariability = fmi3_interval_variability_unknown;
     }

--- a/src/XML/src/FMI3/fmi3_xml_type.c
+++ b/src/XML/src/FMI3/fmi3_xml_type.c
@@ -1112,6 +1112,11 @@ fmi3_xml_clock_type_props_t* fmi3_xml_parse_clock_type_properties(fmi3_xml_parse
     // that attribute. However, the schema files don't allow it.
     int ret = fmi3_xml_parse_attr_as_enum(context, elmID, fmi_attr_id_intervalVariability, 1 /*required*/,
             &props->intervalVariability, fallbackProps->intervalVariability, intervalVariabilityMap);
+    if (ret) {
+        // Note: Eventhough this attribute is required, this does not break the API
+        // accept it anyways
+        props->intervalVariability = fmi3_interval_variability_unknown;
+    }
     
     // The following attributes are optional, failure to parse does not stop parsing of current element
     // with default values
@@ -1194,9 +1199,7 @@ fmi3_xml_clock_type_props_t* fmi3_xml_parse_clock_type_properties(fmi3_xml_parse
         props->intervalDecimal = fallbackProps->intervalDecimal;
     }
 
-    // NULL returns will result in variable parsing failure, resulting in ModelVariable parsing failure
-    // No need to worry about freeing memory of props in that case
-    return ret ? NULL : props; 
+    return props; 
 }
 
 int fmi3_xml_handle_ClockType(fmi3_xml_parser_context_t* context, const char* data) {

--- a/src/XML/src/FMI3/fmi3_xml_variable.c
+++ b/src/XML/src/FMI3/fmi3_xml_variable.c
@@ -2467,6 +2467,8 @@ int fmi3_xml_handle_ModelVariables(fmi3_xml_parser_context_t* context, const cha
         for (size_t i = 0; i < nVars; i++) {
             fmi3_xml_variable_t *variable = jm_vector_get_item(jm_voidp)(&md->variablesOrigOrder, i);
 
+            // These 2 checks can cause secondary errors, if the variable with the given valueReference was invalid
+
             if (variable->hasDerivativeOf) {
                 // Resolve VR to variable.
                 fmi3_value_reference_t vr = variable->derivativeOf.vr;


### PR DESCRIPTION
Failing to parse required attribute "intervalVariability" for Clocks no longer results in failure to parse the element.

Improved tests to check for total number of errors.
Added tests for known secondary errors.