### PR TITLE
Update fmi2_enums.c to solve independent (time) variable start attrit…

### DIFF
--- a/src/Util/src/FMI2/fmi2_enums.c
+++ b/src/Util/src/FMI2/fmi2_enums.c
@@ -118,7 +118,7 @@ fmi2_initial_enu_t fmi2InitialDefaultsTable[fmi2_variability_enu_unknown][fmi2_c
     /* fixed   */   {fmi2_initial_enu_exact,   fmi2_initial_enu_calculated, fmi2_initial_enu_unknown,  fmi2_initial_enu_unknown,    fmi2_initial_enu_calculated, fmi2_initial_enu_unknown},
     /* tunable */   {fmi2_initial_enu_exact,   fmi2_initial_enu_calculated, fmi2_initial_enu_unknown,  fmi2_initial_enu_unknown,    fmi2_initial_enu_calculated, fmi2_initial_enu_unknown},
     /* discrete */  {fmi2_initial_enu_unknown, fmi2_initial_enu_unknown,    fmi2_initial_enu_unknown,  fmi2_initial_enu_calculated, fmi2_initial_enu_calculated, fmi2_initial_enu_unknown},
-    /* continuous */{fmi2_initial_enu_unknown, fmi2_initial_enu_unknown,    fmi2_initial_enu_unknown,  fmi2_initial_enu_calculated, fmi2_initial_enu_calculated, fmi2_initial_enu_unknown}
+    /* continuous */{fmi2_initial_enu_unknown, fmi2_initial_enu_unknown,    fmi2_initial_enu_unknown,  fmi2_initial_enu_calculated, fmi2_initial_enu_calculated, fmi2_initial_enu_calculated}
 };
 
 FMILIB_EXPORT fmi2_variability_enu_t fmi2_get_default_valid_variability(fmi2_causality_enu_t c)


### PR DESCRIPTION
…ube error

the xml check fails on independent variable , it asks for start attribute, (it should not).

this seemed to be working before changing this enum.

either change the check funnction (another pull request) or