### PR TITLE
Give baseuser in ci/dev-containers sudo access

### DIFF
--- a/build/docker/centos64.Dockerfile
+++ b/build/docker/centos64.Dockerfile
@@ -15,9 +15,9 @@ RUN adduser baseuser && \
 # Install development tools
 # curl is used by certain VSCode extensions
 RUN yum install -yq \
-    vim     tmux    which   wget \
-    doxygen make    gcc-c++ git  \
-    curl    valgrind
+    vim     tmux     which   wget \
+    doxygen make     gcc-c++ git  \
+    curl    valgrind sudo
 
 # Install CMake 3 as an alternative with higher priority, by default CentOS 7 installs CMake 2.
 RUN wget -q https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/${CMAKE_TAR} && \

--- a/build/docker/ubuntu64.Dockerfile
+++ b/build/docker/ubuntu64.Dockerfile
@@ -6,19 +6,19 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 USER root
 
-# Give baseuser appropriate permissions
-RUN adduser baseuser; \
-    passwd  -d "baseuser"; \
-    passwd  -d "root"; \
-    usermod -a -G sudo baseuser
-
 # Install development tools:
 # (curl is used by some VSCode extensions)
 RUN apt-get update && apt-get install -yq    \
     vim          tmux      doxygen           \
     cmake        g++       language-pack-sv  \
     git          curl      valgrind          \
-    ninja-build
+    ninja-build  sudo
+
+# Give baseuser appropriate permissions
+RUN adduser baseuser; \
+    passwd  -d "baseuser"; \
+    passwd  -d "root"; \
+    usermod -a -G sudo baseuser
 
 # Switch to baseuser
 USER baseuser


### PR DESCRIPTION
Convenience for letting the baseuser use the `sudo` command, instead of needing to `su root; <do_commands>; su baseuser`.