### PR TITLE
CMake: Bump minimum required

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,17 +35,17 @@ jobs:
       - uses: actions/checkout@v4
       - name: Build Ninja
         run: |
-          cmake -DCMAKE_INSTALL_PREFIX=C:/Users/runneradmin/fmilib -DFMILIB_GENERATE_DOXYGEN_DOC=0 -B build_ninja -G Ninja -LAH . &&
+          cmake -DCMAKE_INSTALL_PREFIX="$($HOME -replace '\\', '/')/fmilib" -DFMILIB_GENERATE_DOXYGEN_DOC=0 -B build_ninja -G Ninja -LAH . &&
           cmake --build build_ninja --target install --parallel 4
       - name: Test
         run: ctest --test-dir build_ninja --output-on-failure
       - name: Build VS
         run: |
-          cmake -DCMAKE_INSTALL_PREFIX=C:/Users/runneradmin/fmilib_install_vs -DFMILIB_GENERATE_DOXYGEN_DOC=0 -DFMILIB_BUILD_TESTS=OFF -B build_vs -LAH . &&
+          cmake -DCMAKE_INSTALL_PREFIX="$($HOME -replace '\\', '/')/fmilib_install_vs" -DFMILIB_GENERATE_DOXYGEN_DOC=0 -DFMILIB_BUILD_TESTS=OFF -B build_vs -LAH . &&
           cmake --build build_vs --target install --parallel 4
       - name: Test Installation
         run: |
-          cmake -DFMIL_HOME=C:/Users/runneradmin/fmilib_install_vs -B build_test_install_vs -LAH Test/test_installation/ &&
+          cmake -DFMIL_HOME="$($HOME -replace '\\', '/')/fmilib_install_vs" -B build_test_install_vs -LAH Test/test_installation/ &&
           cmake --build build_test_install_vs --target ALL_BUILD &&
           ctest --test-dir build_test_install_vs --output-on-failure
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,18 +22,32 @@ jobs:
           cmake --build build_cmake --target install --parallel 4
       - name: Test
         run: ctest --test-dir build_cmake --output-on-failure
+      - name: Test Installation
+        run: |
+          cmake -DFMIL_HOME=~/.local -B build_test_install -LAH Test/test_installation/
+          cmake --build build_test_install --target all
+          ctest --test-dir build_test_install --output-on-failure
 
   windows:
     runs-on: windows-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - name: Build
+      - name: Build Ninja
         run: |
-          cmake -DCMAKE_INSTALL_PREFIX=C:/Users/runneradmin/fmilib -DFMILIB_GENERATE_DOXYGEN_DOC=0 -B build_cmake -G Ninja -LAH .
-          cmake --build build_cmake --target install --parallel 4
+          cmake -DCMAKE_INSTALL_PREFIX=C:/Users/runneradmin/fmilib -DFMILIB_GENERATE_DOXYGEN_DOC=0 -B build_ninja -G Ninja -LAH . &&
+          cmake --build build_ninja --target install --parallel 4
       - name: Test
-        run: ctest --test-dir build_cmake --output-on-failure
+        run: ctest --test-dir build_ninja --output-on-failure
+      - name: Build VS
+        run: |
+          cmake -DCMAKE_INSTALL_PREFIX=C:/Users/runneradmin/fmilib_install_vs -DFMILIB_GENERATE_DOXYGEN_DOC=0 -DFMILIB_BUILD_TESTS=OFF -B build_vs -LAH . &&
+          cmake --build build_vs --target install --parallel 4
+      - name: Test Installation
+        run: |
+          cmake -DFMIL_HOME=C:/Users/runneradmin/fmilib_install_vs -B build_test_install_vs -LAH Test/test_installation/ &&
+          cmake --build build_test_install_vs --target ALL_BUILD &&
+          ctest --test-dir build_test_install_vs --output-on-failure
 
   macos:
     runs-on: macos-latest
@@ -43,6 +57,11 @@ jobs:
       - name: Build
         run: |
           cmake -DCMAKE_INSTALL_PREFIX=~/.local -DFMILIB_GENERATE_DOXYGEN_DOC=0 -B build_cmake .
-          cmake --build build_cmake --target install --parallel 4
+          cmake --build build_cmake --target install --parallel 3
       - name: Test
         run: ctest --test-dir build_cmake --output-on-failure
+      - name: Test Installation
+        run: |
+          cmake -DFMIL_HOME=~/.local -B build_test_install -LAH Test/test_installation/
+          cmake --build build_test_install --target all
+          ctest --test-dir build_test_install --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,10 +11,7 @@
 #    You should have received a copy of the FMILIB_License.txt file
 #    along with this program. If not, contact Modelon AB <http://www.modelon.com>.
 
-# CMake 3.1.3 or later is required to build Expat & zlib (as ExternalProject). However,
-# keeping 2.8.6 on the FMIL main project for now since updating causes issues
-# with CMP0026 (and more).
-cmake_minimum_required(VERSION 2.8.6 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15)
 
 # Prohibit in-source build
 if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
@@ -22,16 +19,6 @@ if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
 endif()
 
 project(FMILibrary)
-
-# Only check this when developing. (Project minimum required is less.)
-if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.3")
-    # Require that we specify when using "byproducts" (i.e. files in the build tree without any explicit target)
-    # to prevent problems with Ninja.
-    cmake_policy(SET CMP0058 NEW)
-endif()
-
-# Avoid warnings in mergestaticlibs.cmake. TODO: Fix the warnings.
-cmake_policy(SET CMP0026 OLD)
 
 # Verify that float parsing will work for the platform/compiler config. Ignoring CHAR_BIT for exotic platforms.
 include(CheckTypeSize)
@@ -331,14 +318,12 @@ endif()
 
 if(FMILIB_BUILD_STATIC_LIB)
     include(mergestaticlibs)
+    merge_static_libs(fmilib ${FMILIB_SUBLIBS})
     if(WIN32)
-        merge_static_libs(fmilib ${FMILIB_SUBLIBS})
-        target_link_libraries(fmilib shlwapi)
-    else()
-        merge_static_libs(fmilib ${FMILIB_SUBLIBS})
+        target_link_libraries(fmilib PUBLIC shlwapi)
     endif()
     if(UNIX)
-        target_link_libraries(fmilib dl)
+        target_link_libraries(fmilib PUBLIC dl)
     endif()
     set(FMILIB_TARGETS ${FMILIB_TARGETS} fmilib)
     # Set PUBLIC include_directories such that test targets that link with fmilib inherit

--- a/Config.cmake/Minizip/CMakeLists.txt
+++ b/Config.cmake/Minizip/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.15)
 
 project(minizip C)
 

--- a/Config.cmake/runtime_test.cmake
+++ b/Config.cmake/runtime_test.cmake
@@ -75,9 +75,6 @@ add_executable(compress_test_fmu_zip ${FMIL_TEST_DIR}/compress_test_fmu_zip.c)
 target_link_libraries(compress_test_fmu_zip fmizip)
 target_include_directories(compress_test_fmu_zip PRIVATE ${FMIL_TEST_INCLUDE_DIRS})
 
-#Path to the executable
-get_property(COMPRESS_EXECUTABLE TARGET compress_test_fmu_zip PROPERTY LOCATION)
-
 if(MSVC)
     # default in MSVC for Debug build is incremental linking,
     # but dlls linked with this flag cannot be loaded with LoadLibrary
@@ -134,7 +131,7 @@ function(compress_fmu OUTPUT_FOLDER_T MODEL_IDENTIFIER_T FILE_NAME_CS_ME_EXT_T T
         COMMAND "${CMAKE_COMMAND}" -E remove -f "${OUTPUT_FOLDER_T}/${FMU_FILE_NAME_T}.fmu"
         COMMAND "${CMAKE_COMMAND}" -E copy "${XML_PATH_T}" "${FMU_OUTPUT_FOLDER_T}/modelDescription.xml"
         COMMAND "${CMAKE_COMMAND}" -E copy "${SHARED_LIBRARY_PATH_T}" "${FMU_OUTPUT_SHARED_LIBRARY_PATH_T}"
-        COMMAND "${COMPRESS_EXECUTABLE}" "${MODEL_IDENTIFIER_T}.fmu" "modelDescription.xml" "${FMU_OUTPUT_SHARED_LIBRARY_PATH_OUT_T}" WORKING_DIRECTORY "${FMU_OUTPUT_FOLDER_T}"
+        COMMAND $<TARGET_FILE:compress_test_fmu_zip> "${MODEL_IDENTIFIER_T}.fmu" "modelDescription.xml" "${FMU_OUTPUT_SHARED_LIBRARY_PATH_OUT_T}" WORKING_DIRECTORY "${FMU_OUTPUT_FOLDER_T}"
         COMMAND "${CMAKE_COMMAND}" -E copy "${FMU_OUTPUT_FOLDER_T}/${MODEL_IDENTIFIER_T}.fmu" "${OUTPUT_FOLDER_T}/${FMU_FILE_NAME_T}.fmu"
     )
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@ Note that version 2.1 is the first version with release notes. Please see the co
 ## 3.0.3
 
 - Use `c99_snprintf` third-party dependency only when compiling with MSVC 2015 and lower
+- Bump minimum cmake version 3.15 and enable compatibility with 4.x.
 
 ## 3.0.2
 

--- a/Test/test_installation/CMakeLists.txt
+++ b/Test/test_installation/CMakeLists.txt
@@ -11,14 +11,14 @@
 #    You should have received a copy of the FMILIB_License.txt file
 #    along with this program. If not, contact Modelon AB <http://www.modelon.com>.
 
-cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15)
 
 # Performs a smoke test on the install directory of FMIL. Verifies for example
 # that:
 #   - All include files have been installed
 #   - No XML headers etc. are included in the import headers
 #   - That libraries are present and functions can be called
-project(TestInstallation)
+project(TestInstallation C)
 
 set_property(GLOBAL PROPERTY C_STANDARD          99)
 set_property(GLOBAL PROPERTY C_STANDARD_REQUIRED ON)
@@ -48,11 +48,7 @@ enable_testing()
 # Import FMIL
 add_library(fmilib STATIC IMPORTED)
 set_property(TARGET fmilib PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${FMIL_HOME}/include")
-if(MSVC)
-    set_property(TARGET fmilib PROPERTY IMPORTED_LOCATION "${FMIL_HOME}/lib/fmilib.lib")
-else()
-    set_property(TARGET fmilib PROPERTY IMPORTED_LOCATION "${FMIL_HOME}/lib/libfmilib.a")
-endif()
+set_property(TARGET fmilib PROPERTY IMPORTED_LOCATION "${FMIL_HOME}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}fmilib${CMAKE_STATIC_LIBRARY_SUFFIX}")
 
 # Build the test
 add_executable(main main.c)
@@ -78,20 +74,13 @@ add_test(test_installation main)
 # Import FMIL
 add_library(fmilib_shared SHARED IMPORTED)
 set_property(TARGET fmilib_shared PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${FMIL_HOME}/include")
-if(MSVC)
-    set_property(TARGET fmilib_shared PROPERTY IMPORTED_LOCATION "${FMIL_HOME}/lib/fmilib_shared.dll")
-    set_property(TARGET fmilib_shared PROPERTY IMPORTED_IMPLIB   "${FMIL_HOME}/lib/fmilib_shared.lib")
-elseif(MINGW)
-    set_property(TARGET fmilib_shared PROPERTY IMPORTED_LOCATION "${FMIL_HOME}/lib/libfmilib_shared.dll")
-    set_property(TARGET fmilib_shared PROPERTY IMPORTED_IMPLIB   "${FMIL_HOME}/lib/libfmilib_shared.dll.a")
-else()
-    set_property(TARGET fmilib_shared PROPERTY IMPORTED_LOCATION "${FMIL_HOME}/lib/libfmilib_shared.so")
-endif()
+set_property(TARGET fmilib_shared PROPERTY IMPORTED_LOCATION "${FMIL_HOME}/lib/${CMAKE_SHARED_LIBRARY_PREFIX}fmilib_shared${CMAKE_SHARED_LIBRARY_SUFFIX}")
+set_property(TARGET fmilib_shared PROPERTY IMPORTED_IMPLIB "${FMIL_HOME}/lib/${CMAKE_IMPORT_LIBRARY_PREFIX}fmilib_shared${CMAKE_IMPORT_LIBRARY_SUFFIX}")
 
 # Build the test
 add_executable(main_shared main.c)
 if(WIN32)
-    target_link_libraries(main_shared PRIVATE fmilib_shared Shlwapi)
+    target_link_libraries(main_shared PRIVATE fmilib_shared shlwapi)
 else()
     target_link_libraries(main_shared PRIVATE fmilib_shared dl)
 endif()


### PR DESCRIPTION
Allows to build without deprecation warnings from cmake>=3.15 and enables compatibility with cmake 4.x

Closes #152