### PR TITLE
Fix fmi3_import_collect_model_counts for binary and clock vars

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,10 @@ Note that version 2.1 is the first version with release notes. Please see the co
 - [BREAKING] Removed unused `instanceEnvironment` and `logMessage` inputs from `fmi3_import_instantiate_*` functions.
     - The corresponding CAPI calls use `instanceEnvironment` and `logMessage` from `fmi3_import_create_dllfmu`.
 
+### Improvements
+
+- Fixed crash when calling `fmi3_import_collect_model_counts` and the model contained Binary or Clock variables.
+
 ## 3.0a4
 
 ### Improvements

--- a/Test/FMI3/fmi3_import_convenience_test.cpp
+++ b/Test/FMI3/fmi3_import_convenience_test.cpp
@@ -225,6 +225,35 @@ TEST_CASE("Test model counts causality") {
     fmi3_testutil_import_free(tfmu);
 }
 
+TEST_CASE("Test model counts type") {
+    const char* xmldir = FMI3_TEST_XML_DIR "/convenience/valid/modelCountsType";
+    fmi3_testutil_import_t* tfmu = fmi3_testutil_parse_xml_with_log(xmldir);
+    fmi3_import_t* xml = tfmu->fmu;
+    REQUIRE(xml != nullptr);
+
+    fmi3_import_model_counts_t counts;
+    fmi3_import_collect_model_counts(xml, &counts);
+
+    REQUIRE(counts.num_float64_vars == 1);
+    REQUIRE(counts.num_float32_vars == 2);
+    REQUIRE(counts.num_int64_vars   == 3);
+    REQUIRE(counts.num_int32_vars   == 4);
+    REQUIRE(counts.num_int16_vars   == 5);
+    REQUIRE(counts.num_int8_vars    == 6);
+    REQUIRE(counts.num_uint64_vars  == 7);
+    REQUIRE(counts.num_uint32_vars  == 8);
+    REQUIRE(counts.num_uint16_vars  == 9);
+    REQUIRE(counts.num_uint8_vars   == 10);
+    REQUIRE(counts.num_enum_vars    == 11);
+    REQUIRE(counts.num_bool_vars    == 12);
+    REQUIRE(counts.num_string_vars  == 13);
+    REQUIRE(counts.num_binary_vars  == 14);
+    REQUIRE(counts.num_clock_vars   == 15);
+
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 0);
+    fmi3_testutil_import_free(tfmu);
+}
+
 TEST_CASE("Get variable from alias name") {
     const char* xmldir = FMI3_TEST_XML_DIR "/convenience/valid/get_variable_by_alias_name1";
     fmi3_testutil_import_t* tfmu = fmi3_testutil_parse_xml_with_log(xmldir);

--- a/Test/FMI3/parser_test_xmls/convenience/valid/modelCountsType/modelDescription.xml
+++ b/Test/FMI3/parser_test_xmls/convenience/valid/modelCountsType/modelDescription.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fmiModelDescription fmiVersion="3.0" modelName="" instantiationToken="">
+<ModelExchange modelIdentifier="modelCountsType"/>
+
+<TypeDefinitions>
+    <EnumerationType name="MyEnum">
+        <Item name="enum0" value="0"/>
+    </EnumerationType>
+</TypeDefinitions>
+
+<ModelVariables>
+  <!-- Variables with different types to test model counts -->
+
+  <Float64 name="f64_1" valueReference="1"/>
+
+  <Float32 name="f32_1" valueReference="2"/>
+  <Float32 name="f32_2" valueReference="3"/>
+
+  <Int64 name="i64_1" valueReference="4"/>
+  <Int64 name="i64_2" valueReference="5"/>
+  <Int64 name="i64_3" valueReference="6"/>
+
+  <Int32 name="i32_1" valueReference="7"/>
+  <Int32 name="i32_3" valueReference="8"/>
+  <Int32 name="i32_4" valueReference="9"/>
+  <Int32 name="i32_5" valueReference="10"/>
+
+  <Int16 name="i16_1" valueReference="11"/>
+  <Int16 name="i16_2" valueReference="12"/>
+  <Int16 name="i16_3" valueReference="13"/>
+  <Int16 name="i16_4" valueReference="14"/>
+  <Int16 name="i16_5" valueReference="15"/>
+
+  <Int8 name="i8_1" valueReference="16"/>
+  <Int8 name="i8_2" valueReference="17"/>
+  <Int8 name="i8_3" valueReference="18"/>
+  <Int8 name="i8_4" valueReference="19"/>
+  <Int8 name="i8_5" valueReference="20"/>
+  <Int8 name="i8_6" valueReference="21"/>
+
+  <UInt64 name="u64_1" valueReference="22"/>
+  <UInt64 name="u64_2" valueReference="23"/>
+  <UInt64 name="u64_3" valueReference="24"/>
+  <UInt64 name="u64_4" valueReference="25"/>
+  <UInt64 name="u64_5" valueReference="26"/>
+  <UInt64 name="u64_6" valueReference="27"/>
+  <UInt64 name="u64_7" valueReference="28"/>
+
+  <UInt32 name="u32_1" valueReference="29"/>
+  <UInt32 name="u32_2" valueReference="30"/>
+  <UInt32 name="u32_3" valueReference="31"/>
+  <UInt32 name="u32_4" valueReference="32"/>
+  <UInt32 name="u32_5" valueReference="33"/>
+  <UInt32 name="u32_6" valueReference="34"/>
+  <UInt32 name="u32_7" valueReference="35"/>
+  <UInt32 name="u32_8" valueReference="36"/>
+
+  <UInt16 name="u16_1"  valueReference="37"/>
+  <UInt16 name="u16_2"  valueReference="38"/>
+  <UInt16 name="u16_3"  valueReference="39"/>
+  <UInt16 name="u16_4"  valueReference="40"/>
+  <UInt16 name="u16_5"  valueReference="41"/>
+  <UInt16 name="u16_6"  valueReference="42"/>
+  <UInt16 name="u16_7"  valueReference="43"/>
+  <UInt16 name="u16_8"  valueReference="44"/>
+  <UInt16 name="u16_9"  valueReference="45"/>
+
+  <UInt8 name="u8_1"  valueReference="46"/>
+  <UInt8 name="u8_2"  valueReference="47"/>
+  <UInt8 name="u8_3"  valueReference="48"/>
+  <UInt8 name="u8_4"  valueReference="49"/>
+  <UInt8 name="u8_5"  valueReference="50"/>
+  <UInt8 name="u8_6"  valueReference="51"/>
+  <UInt8 name="u8_7"  valueReference="52"/>
+  <UInt8 name="u8_8"  valueReference="53"/>
+  <UInt8 name="u8_9"  valueReference="54"/>
+  <UInt8 name="u8_10" valueReference="55"/>
+
+  <Enumeration name="enum_1"  valueReference="56" declaredType="MyEnum"/>
+  <Enumeration name="enum_2"  valueReference="57" declaredType="MyEnum"/>
+  <Enumeration name="enum_3"  valueReference="58" declaredType="MyEnum"/>
+  <Enumeration name="enum_4"  valueReference="59" declaredType="MyEnum"/>
+  <Enumeration name="enum_5"  valueReference="60" declaredType="MyEnum"/>
+  <Enumeration name="enum_6"  valueReference="61" declaredType="MyEnum"/>
+  <Enumeration name="enum_7"  valueReference="62" declaredType="MyEnum"/>
+  <Enumeration name="enum_8"  valueReference="63" declaredType="MyEnum"/>
+  <Enumeration name="enum_9"  valueReference="64" declaredType="MyEnum"/>
+  <Enumeration name="enum_10" valueReference="65" declaredType="MyEnum"/>
+  <Enumeration name="enum_11" valueReference="66" declaredType="MyEnum"/>
+
+  <Boolean name="boolean_1"  valueReference="67"/>
+  <Boolean name="boolean_2"  valueReference="68"/>
+  <Boolean name="boolean_3"  valueReference="69"/>
+  <Boolean name="boolean_4"  valueReference="70"/>
+  <Boolean name="boolean_5"  valueReference="71"/>
+  <Boolean name="boolean_6"  valueReference="72"/>
+  <Boolean name="boolean_7"  valueReference="73"/>
+  <Boolean name="boolean_8"  valueReference="74"/>
+  <Boolean name="boolean_9"  valueReference="75"/>
+  <Boolean name="boolean_10" valueReference="76"/>
+  <Boolean name="boolean_11" valueReference="77"/>
+  <Boolean name="boolean_12" valueReference="78"/>
+
+  <String name="string_1"  valueReference="79"/>
+  <String name="string_2"  valueReference="80"/>
+  <String name="string_3"  valueReference="81"/>
+  <String name="string_4"  valueReference="82"/>
+  <String name="string_5"  valueReference="83"/>
+  <String name="string_6"  valueReference="84"/>
+  <String name="string_7"  valueReference="85"/>
+  <String name="string_8"  valueReference="86"/>
+  <String name="string_9"  valueReference="87"/>
+  <String name="string_10" valueReference="88"/>
+  <String name="string_11" valueReference="89"/>
+  <String name="string_12" valueReference="90"/>
+  <String name="string_13" valueReference="91"/>
+
+  <Binary name="binary_1"  valueReference="92"/>
+  <Binary name="binary_2"  valueReference="93"/>
+  <Binary name="binary_3"  valueReference="94"/>
+  <Binary name="binary_4"  valueReference="95"/>
+  <Binary name="binary_5"  valueReference="96"/>
+  <Binary name="binary_6"  valueReference="97"/>
+  <Binary name="binary_7"  valueReference="98"/>
+  <Binary name="binary_8"  valueReference="99"/>
+  <Binary name="binary_9"  valueReference="100"/>
+  <Binary name="binary_10" valueReference="101"/>
+  <Binary name="binary_11" valueReference="102"/>
+  <Binary name="binary_12" valueReference="103"/>
+  <Binary name="binary_13" valueReference="104"/>
+  <Binary name="binary_14" valueReference="105"/>
+
+  <Clock name="clock_1"  valueReference="106" intervalVariability="constant"/>
+  <Clock name="clock_2"  valueReference="107" intervalVariability="constant"/>
+  <Clock name="clock_3"  valueReference="108" intervalVariability="constant"/>
+  <Clock name="clock_4"  valueReference="109" intervalVariability="constant"/>
+  <Clock name="clock_5"  valueReference="110" intervalVariability="constant"/>
+  <Clock name="clock_6"  valueReference="111" intervalVariability="constant"/>
+  <Clock name="clock_7"  valueReference="112" intervalVariability="constant"/>
+  <Clock name="clock_8"  valueReference="113" intervalVariability="constant"/>
+  <Clock name="clock_9"  valueReference="114" intervalVariability="constant"/>
+  <Clock name="clock_10" valueReference="115" intervalVariability="constant"/>
+  <Clock name="clock_11" valueReference="116" intervalVariability="constant"/>
+  <Clock name="clock_12" valueReference="117" intervalVariability="constant"/>
+  <Clock name="clock_13" valueReference="118" intervalVariability="constant"/>
+  <Clock name="clock_14" valueReference="119" intervalVariability="constant"/>
+  <Clock name="clock_15" valueReference="120" intervalVariability="constant"/>
+</ModelVariables>
+
+<ModelStructure/>
+
+</fmiModelDescription>

--- a/src/Import/include/FMI3/fmi3_import_convenience.h
+++ b/src/Import/include/FMI3/fmi3_import_convenience.h
@@ -98,6 +98,10 @@ typedef struct {
     unsigned int num_bool_vars;
     /** \brief  Number of string variables*/
     unsigned int num_string_vars;
+    /** \brief  Number of binary variables*/
+    unsigned int num_binary_vars;
+    /** \brief  Number of clock variables*/
+    unsigned int num_clock_vars;
 } fmi3_import_model_counts_t;
 
 /**

--- a/src/Import/src/FMI3/fmi3_import_convenience.c
+++ b/src/Import/src/FMI3/fmi3_import_convenience.c
@@ -119,6 +119,12 @@ void fmi3_import_collect_model_counts(fmi3_import_t* fmu, fmi3_import_model_coun
         case fmi3_base_type_enum:
             counts->num_enum_vars++;
             break;
+        case fmi3_base_type_binary:
+            counts->num_binary_vars++;
+            break;
+        case fmi3_base_type_clock:
+            counts->num_clock_vars++;
+            break;
         default:
             assert(0);
         }


### PR DESCRIPTION
We’ve forgot to handle Binary and Clock variables in `fmi3_import_collect_model_counts()` which leads to a crash (`assert(0)`) when the model contains any such variables.