### PR TITLE
Use plain path instead of URI for resourcePath

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -22,6 +22,7 @@ Note that version 2.1 is the first version with release notes. Please see the co
 - Fixed an issue where enum variables min/max attributes were incorrectly handled as `int32`, instead of `int64`.
     - [BREAKING] Changed return types of `fmi3_import_get_enum_variable_min` and `fmi3_import_get_enum_variable_max` from `int` to `fmi3_int64_t`.
 - For FMI3, added a missing trailing file separator to `resourcePath`.
+- For FMI3, removed `file` URI prefix for `resourcePath`.
 
 ### Improvements
 

--- a/Test/FMI3/fmi3_import_sim_me_test.cpp
+++ b/Test/FMI3/fmi3_import_sim_me_test.cpp
@@ -356,6 +356,9 @@ TEST_CASE("Test fallback/default value(s) passed to fmi3Instantiate") {
     fmi3_import_t* fmu = tfmu->fmu;
     REQUIRE(fmu != nullptr);
 
+    // TODO: Various issues related to parsing of Annotations
+    REQUIRE(fmi3_testutil_get_num_problems(tfmu) == 5);
+
     REQUIRE((fmi3_import_get_fmu_kind(fmu) & fmi3_fmu_kind_me) == fmi3_fmu_kind_me);
 
     // Set logger:

--- a/Test/FMI3/fmi3_import_sim_me_test.cpp
+++ b/Test/FMI3/fmi3_import_sim_me_test.cpp
@@ -352,7 +352,8 @@ TEST_CASE("Test fallback/default value(s) passed to fmi3Instantiate") {
     REQUIRE(context != nullptr);
     REQUIRE(fmi_import_get_fmi_version(context, FMU3_ME_PATH, tmpPath) == fmi_version_3_0_enu);
 
-    fmi3_import_t* fmu = fmi3_import_parse_xml(context, tmpPath, NULL);
+    fmi3_testutil_import_t* tfmu = fmi3_testutil_parse_xml_with_log(tmpPath);
+    fmi3_import_t* fmu = tfmu->fmu;
     REQUIRE(fmu != nullptr);
 
     REQUIRE((fmi3_import_get_fmu_kind(fmu) & fmi3_fmu_kind_me) == fmi3_fmu_kind_me);
@@ -382,7 +383,7 @@ TEST_CASE("Test fallback/default value(s) passed to fmi3Instantiate") {
     // Clean up
     REQUIRE(fmi3_import_terminate(fmu) == fmi3_status_ok);
     fmi3_import_free_instance(fmu);
-    fmi3_import_free(fmu);
+    fmi3_testutil_import_free(tfmu);
     fmi_import_free_context(context);
     REQUIRE(fmi_import_rmdir(&callbacks, tmpPath) == jm_status_success);
     callbacks.free((void*)tmpPath);

--- a/Test/FMI3/fmi3_import_sim_me_test.cpp
+++ b/Test/FMI3/fmi3_import_sim_me_test.cpp
@@ -379,7 +379,10 @@ TEST_CASE("Test fallback/default value(s) passed to fmi3Instantiate") {
 #endif
     REQUIRE(strcmp(expected, loggedResourcePath) == 0);
 
-    fmi3_import_destroy_dllfmu(fmu);
+    // Clean up
+    REQUIRE(fmi3_import_terminate(fmu) == fmi3_status_ok);
+    fmi3_import_free_instance(fmu);
+    fmi3_import_free(fmu);
     fmi_import_free_context(context);
     REQUIRE(fmi_import_rmdir(&callbacks, tmpPath) == jm_status_success);
     callbacks.free((void*)tmpPath);

--- a/Test/FMI3/fmu_dummy/fmu3_model_me.c
+++ b/Test/FMI3/fmu_dummy/fmu3_model_me.c
@@ -49,6 +49,11 @@ FMI3_Export fmi3Instance fmi3InstantiateModelExchange(
         fmi3InstanceEnvironment instanceEnvironment,
         fmi3LogMessageCallback  logMessage)
 {
+    // For testing:
+    char msg[4096] = "TEST_RESOURCE_PATH=";
+    strcpy(msg + strlen(msg), resourcePath);
+    logMessage(instanceEnvironment, fmi3OK, "Debug", msg);
+
     return fmi_instantiate(fmu_type_me,
                            instanceName,
                            instantiationToken,


### PR DESCRIPTION
FMI 2 expects a URI for the `resourcePath` argument given to fmi2Instantiate, but in FMI 3 it's just a plain path. I.e. not a URI, and should therefore not get `file` URI prefix.