### PR TITLE
Partial revert of #195 due to MSVC link issues

### DIFF
--- a/src/ZIP/src/fmi_minizip.c
+++ b/src/ZIP/src/fmi_minizip.c
@@ -33,8 +33,7 @@
         #endif
 #endif
 
-/* MODIFICATION: fopen64 etc. are not defined for MSVC. Original minizip handles this via ioapi.h, but minizip-ng doesn't. */
-#if defined(__APPLE__) || defined(__HAIKU__) || defined(MINIZIP_FOPEN_NO_64) || defined(_MSC_VER)
+#if defined(__APPLE__) || defined(__HAIKU__) || defined(MINIZIP_FOPEN_NO_64)
 // In darwin and perhaps other BSD variants off_t is a 64 bit value, hence no need for specific 64 bit functions
 #define FOPEN_FUNC(filename, mode) fopen(filename, mode)
 #define FTELLO_FUNC(stream) ftello(stream)


### PR DESCRIPTION
On master:

```
fmizip.lib(fmi_minizip.obj) : error LNK2019: unresolved external symbol fseeko referenced in function fmi_minizip [<...>\build_msvc_md\compress_test_fmu_zip.vcxproj]
fmizip.lib(fmi_minizip.obj) : error LNK2019: unresolved external symbol ftello referenced in function fmi_minizip [<...>\build_msvc_md\compress_test_fmu_zip.vcxproj]
```

In #195 this didn't appear to be needed for fmi_minizip.c (only fmi_miniunz.c), but was added to keep changes similar. However it appears that didn't work out due to different subset of macro-defined functions being used.