### PR TITLE
Correct printf format strings

### DIFF
--- a/Test/FMI3/fmi3_import_bouncingball_xml_test.cpp
+++ b/Test/FMI3/fmi3_import_bouncingball_xml_test.cpp
@@ -27,6 +27,7 @@
 #include <stdarg.h>
 #include <assert.h>
 #include <time.h>
+#include <inttypes.h>
 
 #include "fmilib.h"
 #include "config_test.h"
@@ -228,7 +229,7 @@ void printVariableInfo(fmi3_import_t* fmu,
             break;
         }
         case fmi3_base_type_enum:{
-            printf("start = %lld\n", fmi3_import_get_enum_variable_start(fmi3_import_get_variable_as_enum(v)));
+            printf("start = %" PRId64 "\n", fmi3_import_get_enum_variable_start(fmi3_import_get_variable_as_enum(v)));
             break;
         }
         default:

--- a/Test/FMI3/fmi3_import_bouncingball_xml_test.cpp
+++ b/Test/FMI3/fmi3_import_bouncingball_xml_test.cpp
@@ -229,7 +229,8 @@ void printVariableInfo(fmi3_import_t* fmu,
             break;
         }
         case fmi3_base_type_enum:{
-            printf("start = %" PRId64 "\n", fmi3_import_get_enum_variable_start(fmi3_import_get_variable_as_enum(v)));
+            // doesn't work on mingw_64, but there are enums in bouncing ball
+            // printf("start = %" PRId64 "\n", fmi3_import_get_enum_variable_start(fmi3_import_get_variable_as_enum(v)));
             break;
         }
         default:

--- a/Test/FMI3/fmi3_import_test.c
+++ b/Test/FMI3/fmi3_import_test.c
@@ -30,7 +30,7 @@
 static void fmi3logger(fmi3_instance_environment_t env, fmi3_status_t status, fmi3_string_t category, fmi3_string_t message)
 {
     char msg[BUFFER];
-    jm_snprintf(msg, BUFFER, message);
+    jm_snprintf(msg, BUFFER, "%s", message);
     printf("fmiStatus = %s;  %s: %s\n", fmi3_status_to_string(status), category, msg);
 }
 

--- a/Test/FMI3/fmu_dummy/fmu3_model.c
+++ b/Test/FMI3/fmu_dummy/fmu3_model.c
@@ -49,13 +49,13 @@ static int calc_initialize(instance_ptr_t inst)
         snprintf(msg, msg_sz, "Init #%d#=%g", VAR_R_HEIGHT, inst->states[VAR_R_HEIGHT]);
         inst->cb.logMessage(inst->cb.instanceEnvironment, fmi3OK, "INFO", msg);
 
-        snprintf(msg, msg_sz, "Init #%d#=%g", VAR_R_HEIGHT, "Init #%d#=%g",VAR_R_HEIGHT_SPEED, inst->states[VAR_R_HEIGHT_SPEED]);
+        snprintf(msg, msg_sz, "Init #%d#=%g",VAR_R_HEIGHT_SPEED, inst->states[VAR_R_HEIGHT_SPEED]);
         inst->cb.logMessage(inst->cb.instanceEnvironment, fmi3OK, "INFO", msg);
 
-        snprintf(msg, msg_sz, "Init #%d#=%g", VAR_R_HEIGHT, "Init #%d#=%g",VAR_R_HEIGHT_SPEED, "Init #%d#=%g",VAR_R_GRATIVY, inst->reals[VAR_R_GRATIVY]);
+        snprintf(msg, msg_sz, "Init #%d#=%g",VAR_R_GRATIVY, inst->reals[VAR_R_GRATIVY]);
         inst->cb.logMessage(inst->cb.instanceEnvironment, fmi3OK, "INFO", msg);
 
-        snprintf(msg, msg_sz, "Init #%d#=%g", VAR_R_HEIGHT, "Init #%d#=%g",VAR_R_HEIGHT_SPEED, "Init #%d#=%g",VAR_R_BOUNCE_CONF, inst->reals[VAR_R_BOUNCE_CONF]);
+        snprintf(msg, msg_sz, "Init #%d#=%g",VAR_R_BOUNCE_CONF, inst->reals[VAR_R_BOUNCE_CONF]);
         inst->cb.logMessage(inst->cb.instanceEnvironment, fmi3OK, "INFO", msg);
     }
     return 0;

--- a/src/Import/include/FMI1/fmi1_import_convenience.h
+++ b/src/Import/include/FMI1/fmi1_import_convenience.h
@@ -107,7 +107,7 @@ void fmi1_import_expand_variable_references(fmi1_import_t* fmu, const char* msgI
     Note that this function is not thread safe due to the use of the global list.
 */
 FMILIB_EXPORT 
-void  fmi1_log_forwarding(fmi1_component_t c, fmi1_string_t instanceName, fmi1_status_t status, fmi1_string_t category, fmi1_string_t message, ...);
+void  fmi1_log_forwarding(fmi1_component_t c, fmi1_string_t instanceName, fmi1_status_t status, fmi1_string_t category, fmi1_string_t message, ...) jm_printf_format(5);
 
 /**
     \brief An implementation of FMI 1.0 logger that forwards the messages to logger function inside ::jm_callbacks structure.
@@ -115,12 +115,12 @@ void  fmi1_log_forwarding(fmi1_component_t c, fmi1_string_t instanceName, fmi1_s
     See fmi1_log_forwarding() for more information.
 */
 FMILIB_EXPORT 
-void  fmi1_log_forwarding_v(fmi1_component_t c, fmi1_string_t instanceName, fmi1_status_t status, fmi1_string_t category, fmi1_string_t message, va_list args);
+void  fmi1_log_forwarding_v(fmi1_component_t c, fmi1_string_t instanceName, fmi1_status_t status, fmi1_string_t category, fmi1_string_t message, va_list args) jm_vprintf_format(5);
 
 
 /** \brief  Default FMI 1.0 logger may be used when instantiating FMUs */
 FMILIB_EXPORT
-void  fmi1_default_callback_logger(fmi1_component_t c, fmi1_string_t instanceName, fmi1_status_t status, fmi1_string_t category, fmi1_string_t message, ...);
+void  fmi1_default_callback_logger(fmi1_component_t c, fmi1_string_t instanceName, fmi1_status_t status, fmi1_string_t category, fmi1_string_t message, ...) jm_printf_format(5);
 
 /** \brief  Given ::fmi1_callback_functions_t logger (fmi1_logger), the ::jm_callbacks logger may be setup to redirect the messages to the fmi1_logger.
 

--- a/src/Import/include/FMI2/fmi2_import_convenience.h
+++ b/src/Import/include/FMI2/fmi2_import_convenience.h
@@ -112,7 +112,7 @@ void fmi2_import_expand_variable_references(fmi2_import_t* fmu, const char* msgI
     Note that this function is not thread safe due to the use of the global list.
 */
 FMILIB_EXPORT 
-void  fmi2_log_forwarding(fmi2_component_t c, fmi2_string_t instanceName, fmi2_status_t status, fmi2_string_t category, fmi2_string_t message, ...);
+void  fmi2_log_forwarding(fmi2_component_t c, fmi2_string_t instanceName, fmi2_status_t status, fmi2_string_t category, fmi2_string_t message, ...) jm_printf_format(5);
 
 /**
     \brief An implementation of FMI 2.0 logger that forwards the messages to logger function inside ::jm_callbacks structure.
@@ -120,12 +120,12 @@ void  fmi2_log_forwarding(fmi2_component_t c, fmi2_string_t instanceName, fmi2_s
     See fmi2_log_forwarding() for more information.
 */
 FMILIB_EXPORT 
-void  fmi2_log_forwarding_v(fmi2_component_t c, fmi2_string_t instanceName, fmi2_status_t status, fmi2_string_t category, fmi2_string_t message, va_list args);
+void  fmi2_log_forwarding_v(fmi2_component_t c, fmi2_string_t instanceName, fmi2_status_t status, fmi2_string_t category, fmi2_string_t message, va_list args) jm_vprintf_format(5);
 
 
 /** \brief  Default FMI 2.0 logger may be used when instantiating FMUs */
 FMILIB_EXPORT
-void  fmi2_default_callback_logger(fmi2_component_t c, fmi2_string_t instanceName, fmi2_status_t status, fmi2_string_t category, fmi2_string_t message, ...);
+void  fmi2_default_callback_logger(fmi2_component_t c, fmi2_string_t instanceName, fmi2_status_t status, fmi2_string_t category, fmi2_string_t message, ...) jm_printf_format(5);
 
 /** \brief  Given ::fmi2_callback_functions_t logger (fmi2_logger), the ::jm_callbacks logger may be setup to redirect the messages to the fmi2_logger.
 

--- a/src/Import/src/FMI1/fmi1_import_capi.c
+++ b/src/Import/src/FMI1/fmi1_import_capi.c
@@ -137,7 +137,7 @@ jm_status_enu_t fmi1_import_create_dllfmu(fmi1_import_t* fmu, fmi1_callback_func
             jm_log_debug(fmu->callbacks, module, "Created an empty active fmu list");
         }
         jm_vector_push_back(jm_voidp)(fmi1_import_active_fmu, fmu);
-        jm_log_debug(fmu->callbacks, module, "Registrered active fmu(%p)", fmu);
+        jm_log_debug(fmu->callbacks, module, "Registrered active fmu(%p)", (void*)fmu);
     }
 
     return jm_status_success;
@@ -174,7 +174,7 @@ void fmi1_import_destroy_dllfmu(fmi1_import_t* fmu) {
             nFmu = jm_vector_get_size(jm_voidp)(fmi1_import_active_fmu);
             if(index < nFmu) {
                 jm_vector_remove_item(jm_voidp)(fmi1_import_active_fmu,index);
-                jm_log_debug(fmu->callbacks, module, "Unregistrered active fmu(%p)", fmu);
+                jm_log_debug(fmu->callbacks, module, "Unregistrered active fmu(%p)", (void*)fmu);
                 if(nFmu == 1) {
                     jm_vector_free_data(jm_voidp)(fmi1_import_active_fmu);
                     fmi1_import_active_fmu = 0;

--- a/src/Import/src/FMI3/fmi3_import_convenience.c
+++ b/src/Import/src/FMI3/fmi3_import_convenience.c
@@ -308,7 +308,7 @@ void fmi3_log_forwarding(fmi3_instance_environment_t inst, fmi3_status_t status,
     if (fmu) {
         int bufsize = jm_vector_get_size(char)(&fmu->logMessageBufferCoded);
         int len;
-        len = jm_snprintf(curp, bufsize -(curp-buf), message);
+        len = jm_snprintf(curp, bufsize -(curp-buf), "%s", message);
         if (len > (bufsize -(curp-buf+1))) {
             int offset = (curp-buf);
             len = jm_vector_resize(char)(&fmu->logMessageBufferCoded, len + offset + 1) - offset;
@@ -319,7 +319,7 @@ void fmi3_log_forwarding(fmi3_instance_environment_t inst, fmi3_status_t status,
         msg = jm_vector_get_itemp(char)(&fmu->logMessageBufferExpanded,0);
     }
     else {
-        jm_snprintf(curp, BUFSIZE -(curp-buf), message);
+        jm_snprintf(curp, BUFSIZE -(curp-buf), "%s", message);
         strncpy(cb->errMessageBuffer, buf, JM_MAX_ERROR_MESSAGE_SIZE);
         cb->errMessageBuffer[JM_MAX_ERROR_MESSAGE_SIZE - 1] = '\0';
         msg = cb->errMessageBuffer;

--- a/src/Util/include/JM/jm_callbacks.h
+++ b/src/Util/include/JM/jm_callbacks.h
@@ -126,6 +126,28 @@ jm_callbacks* jm_get_default_callbacks(void);
 FMILIB_EXPORT
 void jm_default_logger(jm_callbacks* c, jm_string module, jm_log_level_enu_t log_level, jm_string message);
 
+#ifdef __GNUC__
+/**
+    \brief Macro to check parameters to printf format functions.
+    The GNU C compiler has support for checking printf-like functions for
+    correctness. One just needs to add this attribute at the end of the
+    function declaration. The macro parameter describes the position of the
+    format string in the parameter list.
+*/
+#define jm_printf_format(i) __attribute__ ((format (printf, (i), ((i)+1))))
+/**
+    \brief Macro to check parameters to vprintf format functions.
+    The GNU C compiler has support for checking vprintf-like functions for
+    correctness. One just needs to add this attribute at the end of the
+    function declaration. The macro parameter describes the position of the
+    format string in the parameter list.
+*/
+#define jm_vprintf_format(i) __attribute__ ((format (printf, (i), 0)))
+#else
+#define jm_printf_format(i)
+#define jm_vprintf_format(i)
+#endif
+
 /**
     \brief Send a message to the logger function.
     @param cb - callbacks to be used for reporting;
@@ -134,60 +156,60 @@ void jm_default_logger(jm_callbacks* c, jm_string module, jm_log_level_enu_t log
     @param fmt - "printf" type of format followed by the arguments.
 */
 FMILIB_EXPORT
-void jm_log(jm_callbacks* cb, const char* module, jm_log_level_enu_t log_level, const char* fmt, ...);
+void jm_log(jm_callbacks* cb, const char* module, jm_log_level_enu_t log_level, const char* fmt, ...) jm_printf_format(4);
 
 /** \copydoc jm_log()
     @param ap - variable size argument list.
 */
 FMILIB_EXPORT
-void jm_log_v(jm_callbacks* cb, const char* module, jm_log_level_enu_t log_level, const char* fmt, va_list ap);
+void jm_log_v(jm_callbacks* cb, const char* module, jm_log_level_enu_t log_level, const char* fmt, va_list ap) jm_vprintf_format(4);
 
 /** \brief Send a fatal error message to the logger function. See jm_log() for details.
 */
 FMILIB_EXPORT
-void jm_log_fatal_v(jm_callbacks* cb, const char* module, const char* fmt, va_list ap);
+void jm_log_fatal_v(jm_callbacks* cb, const char* module, const char* fmt, va_list ap) jm_vprintf_format(3);
 /** \brief Send a fatal error message to the logger function. See jm_log() for details.
 */
 FMILIB_EXPORT
-void jm_log_fatal(jm_callbacks* cb, const char* module, const char* fmt, ...);
+void jm_log_fatal(jm_callbacks* cb, const char* module, const char* fmt, ...) jm_printf_format(3);
 
 /** \brief Send a error message to the logger function. See jm_log() for details.
 */
 FMILIB_EXPORT
-void jm_log_error_v(jm_callbacks* cb, const char* module, const char* fmt, va_list ap);
+void jm_log_error_v(jm_callbacks* cb, const char* module, const char* fmt, va_list ap) jm_vprintf_format(3);
 
 /** \brief Send a error message to the logger function. See jm_log() for details.
 */
 FMILIB_EXPORT
-void jm_log_error(jm_callbacks* cb, const char* module, const char* fmt, ...);
+void jm_log_error(jm_callbacks* cb, const char* module, const char* fmt, ...) jm_printf_format(3);
 
 /** \brief Send a warning message to the logger function. See jm_log() for details.
 */
 FMILIB_EXPORT
-void jm_log_warning_v(jm_callbacks* cb, const char* module, const char* fmt, va_list ap);
+void jm_log_warning_v(jm_callbacks* cb, const char* module, const char* fmt, va_list ap) jm_vprintf_format(3);
 
 /** \brief Send a warning message to the logger function. See jm_log() for details.
 */
 FMILIB_EXPORT
-void jm_log_warning(jm_callbacks* cb, const char* module, const char* fmt, ...);
+void jm_log_warning(jm_callbacks* cb, const char* module, const char* fmt, ...) jm_printf_format(3);
 
 /** \brief Send an info message to the logger function. See jm_log() for details.
 */
 FMILIB_EXPORT
-void jm_log_info_v(jm_callbacks* cb, const char* module, const char* fmt, va_list ap);
+void jm_log_info_v(jm_callbacks* cb, const char* module, const char* fmt, va_list ap) jm_vprintf_format(3);
 /** \brief Send an info message to the logger function. See jm_log() for details.
 */
 FMILIB_EXPORT
-void jm_log_info(jm_callbacks* cb, const char* module, const char* fmt, ...);
+void jm_log_info(jm_callbacks* cb, const char* module, const char* fmt, ...) jm_printf_format(3);
 
 /** \brief Send a verbose message to the logger function. See jm_log() for details.
 */
 FMILIB_EXPORT
-void jm_log_verbose_v(jm_callbacks* cb, const char* module, const char* fmt, va_list ap);
+void jm_log_verbose_v(jm_callbacks* cb, const char* module, const char* fmt, va_list ap) jm_vprintf_format(3);
 /** \brief Send a verbose message to the logger function. See jm_log() for details.
 */
 FMILIB_EXPORT
-void jm_log_verbose(jm_callbacks* cb, const char* module, const char* fmt, ...);
+void jm_log_verbose(jm_callbacks* cb, const char* module, const char* fmt, ...) jm_printf_format(3);
 
 /** \brief Convert log level into a string */
 FMILIB_EXPORT
@@ -200,23 +222,25 @@ const char* jm_log_level_to_string(jm_log_level_enu_t level);
     Note that the function is only active if the library is configure with FMILIB_ENABLE_LOG_LEVEL_DEBUG=ON
 */
 FMILIB_EXPORT
-void jm_log_debug_v(jm_callbacks* cb, const char* module, const char* fmt, va_list ap);
+void jm_log_debug_v(jm_callbacks* cb, const char* module, const char* fmt, va_list ap) jm_vprintf_format(3);
 /** \brief Send a debug message to the logger function. See jm_log() for details.
 
     Note that the function is only active if the library is configure with FMILIB_ENABLE_LOG_LEVEL_DEBUG=ON
 */
 FMILIB_EXPORT
-void jm_log_debug(jm_callbacks* cb, const char* module, const char* fmt, ...);
+void jm_log_debug(jm_callbacks* cb, const char* module, const char* fmt, ...) jm_printf_format(3);
 #else
 /** \brief Send a debug message to the logger function. See jm_log() for details.
 
     Note that the function is only active if the library is configure with FMILIB_ENABLE_LOG_LEVEL_DEBUG=ON
 */
+static void jm_log_debug_v(jm_callbacks* cb, const char* module, const char* fmt, va_list ap) jm_vprintf_format(3);
 static void jm_log_debug_v(jm_callbacks* cb, const char* module, const char* fmt, va_list ap) {}
 /** \brief Send a debug message to the logger function. See jm_log() for details.
 
     Note that the function is only active if the library is configure with FMILIB_ENABLE_LOG_LEVEL_DEBUG=ON
 */
+static void jm_log_debug(jm_callbacks* cb, const char* module, const char* fmt, ...) jm_printf_format(3);
 static void jm_log_debug(jm_callbacks* cb, const char* module, const char* fmt, ...) {}
 #endif
 

--- a/src/Util/include/JM/jm_portability.h
+++ b/src/Util/include/JM/jm_portability.h
@@ -160,7 +160,7 @@ jm_status_enu_t jm_rmdir(jm_callbacks* cb, const char* dir);
     For example, compare vsnprintf documentation for MSVC 2013 and 2015.
 */
 FMILIB_EXPORT
-int jm_vsnprintf(char * str, size_t size, const char * fmt, va_list al);
+int jm_vsnprintf(char * str, size_t size, const char * fmt, va_list al) jm_vprintf_format(3);
 
 /**
     \brief C89 compatible implementation of C99 snprintf.
@@ -171,7 +171,7 @@ int jm_vsnprintf(char * str, size_t size, const char * fmt, va_list al);
     See jm_vsnprintf for more info.
 */
 FMILIB_EXPORT
-int jm_snprintf(char * str, size_t size, const char * fmt, ...);
+int jm_snprintf(char * str, size_t size, const char * fmt, ...) jm_printf_format(3);
 
 #ifdef HAVE_VA_COPY
 #define JM_VA_COPY va_copy

--- a/src/XML/src/FMI/fmi_xml_context.c
+++ b/src/XML/src/FMI/fmi_xml_context.c
@@ -17,6 +17,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 
+#include "JM/jm_callbacks.h"
 #include "fmi_xml_context_impl.h"
 
 static char* MODULE="FMIXML";
@@ -59,6 +60,7 @@ void fmi_xml_set_configuration(fmi_xml_context_t *context, int configuration) {
     context->configuration = configuration;
 }
 
+void fmi_xml_fatal(fmi_xml_context_t *context, const char* fmt, ...) jm_printf_format(2);
 void fmi_xml_fatal(fmi_xml_context_t *context, const char* fmt, ...) {
     va_list args;
 

--- a/src/XML/src/FMI1/fmi1_xml_parser.c
+++ b/src/XML/src/FMI1/fmi1_xml_parser.c
@@ -127,7 +127,7 @@ static void fmi1_xml_parse_log_message(fmi1_xml_parser_context_t* context, const
         jm_log_level_enu_t log_level, va_list args) {
     if (context->parser) {
         jm_log(context->callbacks, module, log_level,
-                "Detected on line:%u of modelDescription.xml", XML_GetCurrentLineNumber(context->parser));
+                "Detected on line:%lu of modelDescription.xml", XML_GetCurrentLineNumber(context->parser));
         jm_log_v(context->callbacks, module, log_level, fmt, args);
     } else {
         jm_log_v(context->callbacks, module, log_level, fmt, args);
@@ -384,7 +384,7 @@ static void XMLCALL fmi1_parse_element_start(void *c, const char *elm, const cha
 
     if(context->skipElementCnt) {
         context->skipElementCnt++;
-        jm_log_warning(context->callbacks, module, "[Line:%u] Skipping nested XML element '%s'",
+        jm_log_warning(context->callbacks, module, "[Line:%lu] Skipping nested XML element '%s'",
             XML_GetCurrentLineNumber(context->parser), elm);
         return;
     }
@@ -394,7 +394,7 @@ static void XMLCALL fmi1_parse_element_start(void *c, const char *elm, const cha
     currentElMap = jm_vector_bsearch(fmi1_xml_element_handle_map_t)(context->elmMap, &keyEl, fmi1_xml_compare_elmName);
     if(!currentElMap) {
         /* not found error*/
-        jm_log_error(context->callbacks, module, "[Line:%u] Unknown element '%s' in XML, skipping",
+        jm_log_error(context->callbacks, module, "[Line:%lu] Unknown element '%s' in XML, skipping",
             XML_GetCurrentLineNumber(context->parser), elm);
         context->skipElementCnt = 1;
         return;
@@ -409,7 +409,7 @@ static void XMLCALL fmi1_parse_element_start(void *c, const char *elm, const cha
         if((fmi1_xml_scheme_info[currentID].parentID != parentID) &&
             ((currentID != fmi1_xml_elmID_Capabilities) || (parentID != fmi1_xml_elmID_CoSimulation_Tool))) {
                 jm_log_error(context->callbacks, module,
-                    "[Line:%u] XML element '%s' cannot be placed inside '%s', skipping",
+                    "[Line:%lu] XML element '%s' cannot be placed inside '%s', skipping",
                     XML_GetCurrentLineNumber(context->parser), elm, fmi1_element_handle_map[parentID].elementName);
                 context->skipElementCnt = 1;
                 return;
@@ -418,7 +418,7 @@ static void XMLCALL fmi1_parse_element_start(void *c, const char *elm, const cha
             if(siblingID == currentID) {
                 if(!fmi1_xml_scheme_info[currentID].multipleAllowed) {
                     jm_log_error(context->callbacks, module,
-                        "[Line:%u] Multiple instances of XML element '%s' are not allowed, skipping",
+                        "[Line:%lu] Multiple instances of XML element '%s' are not allowed, skipping",
                         XML_GetCurrentLineNumber(context->parser), elm);
                     context->skipElementCnt = 1;
                     return;
@@ -430,7 +430,7 @@ static void XMLCALL fmi1_parse_element_start(void *c, const char *elm, const cha
 
                 if(lastSiblingIndex >= curSiblingIndex) {
                     jm_log_error(context->callbacks, module,
-                        "[Line:%u] XML element '%s' cannot be placed after element '%s', skipping",
+                        "[Line:%lu] XML element '%s' cannot be placed after element '%s', skipping",
                         XML_GetCurrentLineNumber(context->parser), elm, fmi1_element_handle_map[siblingID].elementName);
                     context->skipElementCnt = 1;
                     return;

--- a/src/XML/src/FMI1/fmi1_xml_parser.h
+++ b/src/XML/src/FMI1/fmi1_xml_parser.h
@@ -188,9 +188,9 @@ int fmi1_xml_alloc_parse_buffer(fmi1_xml_parser_context_t *context, size_t items
 
 void fmi1_xml_free_parse_buffer(fmi1_xml_parser_context_t *context);
 
-void fmi1_xml_parse_fatal(fmi1_xml_parser_context_t *context, const char* fmt, ...);
-void fmi1_xml_parse_error(fmi1_xml_parser_context_t *context, const char* fmt, ...);
-void fmi1_xml_parse_warning(fmi1_xml_parser_context_t* context, const char* fmt, ...);
+void fmi1_xml_parse_fatal(fmi1_xml_parser_context_t *context, const char* fmt, ...) jm_printf_format(2);
+void fmi1_xml_parse_error(fmi1_xml_parser_context_t *context, const char* fmt, ...) jm_printf_format(2);
+void fmi1_xml_parse_warning(fmi1_xml_parser_context_t* context, const char* fmt, ...) jm_printf_format(2);
 
 int fmi1_xml_set_attr_string(fmi1_xml_parser_context_t *context, fmi1_xml_elm_enu_t elmID, fmi1_xml_attr_enu_t attrID, int required, jm_vector(char)* field);
 int fmi1_xml_set_attr_uint(fmi1_xml_parser_context_t *context, fmi1_xml_elm_enu_t elmID, fmi1_xml_attr_enu_t attrID, int required, unsigned int* field, unsigned int defaultVal);

--- a/src/XML/src/FMI2/fmi2_xml_model_structure.c
+++ b/src/XML/src/FMI2/fmi2_xml_model_structure.c
@@ -269,13 +269,13 @@ int fmi2_xml_parse_dependencies(fmi2_xml_parser_context_t *context,
              }
              if(!ch) break;
              if(sscanf(cur, "%d", &ind) != 1) {
-                 fmi2_xml_parse_error(context, "XML element 'Unknown': could not parse item %d in the list for attribute 'dependencies'",
+                 fmi2_xml_parse_error(context, "XML element 'Unknown': could not parse item %zu in the list for attribute 'dependencies'",
                      numDepInd);
                 ms->isValidFlag = 0;
                 return 0;
              }
              if(ind < 1) {
-                 fmi2_xml_parse_error(context, "XML element 'Unknown': item %d=%d is less than one in the list for attribute 'dependencies'",
+                 fmi2_xml_parse_error(context, "XML element 'Unknown': item %zu=%d is less than one in the list for attribute 'dependencies'",
                      numDepInd, ind);
                 ms->isValidFlag = 0;
                 return 0;
@@ -340,7 +340,7 @@ int fmi2_xml_parse_dependencies(fmi2_xml_parser_context_t *context,
                  cur+=8;
              }
              else {
-                 fmi2_xml_parse_error(context, "XML element 'Unknown': could not parse item %d in the list for attribute 'dependenciesKind'",
+                 fmi2_xml_parse_error(context, "XML element 'Unknown': could not parse item %zu in the list for attribute 'dependenciesKind'",
                      numDepKind);
                  ms->isValidFlag = 0;
                  return 0;
@@ -366,7 +366,7 @@ int fmi2_xml_parse_dependencies(fmi2_xml_parser_context_t *context,
     if(listInd && listKind) {
         /* both lists are present - the number of items must match */
         if(numDepInd != numDepKind) {
-            fmi2_xml_parse_error(context, "XML element 'Unknown': different number of items (%u and %u) in the lists for 'dependencies' and 'dependenciesKind'",
+            fmi2_xml_parse_error(context, "XML element 'Unknown': different number of items (%zu and %zu) in the lists for 'dependencies' and 'dependenciesKind'",
                                  numDepInd, numDepKind);
             ms->isValidFlag = 0;
             return 0;

--- a/src/XML/src/FMI2/fmi2_xml_parser.c
+++ b/src/XML/src/FMI2/fmi2_xml_parser.c
@@ -138,7 +138,7 @@ void fmi2_xml_parse_error(fmi2_xml_parser_context_t *context, const char* fmt, .
     va_list args;
     va_start (args, fmt);
     if(context->parser)
-        jm_log_info(context->callbacks, module, "[Line:%u] Detected during parsing:", XML_GetCurrentLineNumber(context->parser));
+        jm_log_info(context->callbacks, module, "[Line:%lu] Detected during parsing:", XML_GetCurrentLineNumber(context->parser));
     jm_log_error_v(context->callbacks, module,fmt, args);
     va_end (args);
 }
@@ -404,7 +404,7 @@ static void XMLCALL fmi2_parse_element_start(void *c, const char *elm, const cha
 
     if(context->skipElementCnt) {
         context->skipElementCnt++;
-        jm_log_warning(context->callbacks, module, "[Line:%u] Skipping nested XML element '%s'",
+        jm_log_warning(context->callbacks, module, "[Line:%lu] Skipping nested XML element '%s'",
             XML_GetCurrentLineNumber(context->parser), elm);
         return;
     }
@@ -414,7 +414,7 @@ static void XMLCALL fmi2_parse_element_start(void *c, const char *elm, const cha
     currentElMap = jm_vector_bsearch(fmi2_xml_element_handle_map_t)(context->elmMap, &keyEl, fmi2_xml_compare_elmName);
     if(!currentElMap) {
         /* not found error*/
-        jm_log_error(context->callbacks, module, "[Line:%u] Unknown element '%s' in XML, skipping",
+        jm_log_error(context->callbacks, module, "[Line:%lu] Unknown element '%s' in XML, skipping",
             XML_GetCurrentLineNumber(context->parser), elm);
         context->skipElementCnt = 1;
         return;
@@ -428,7 +428,7 @@ static void XMLCALL fmi2_parse_element_start(void *c, const char *elm, const cha
 
         if(fmi2_xml_scheme_info[currentID].parentID != parentID) {
                 jm_log_error(context->callbacks, module, 
-                    "[Line:%u] XML element '%s' cannot be placed inside '%s', skipping",
+                    "[Line:%lu] XML element '%s' cannot be placed inside '%s', skipping",
                     XML_GetCurrentLineNumber(context->parser), elm, fmi2_element_handle_map[parentID].elementName);
                 context->skipElementCnt = 1;
                 return;
@@ -437,7 +437,7 @@ static void XMLCALL fmi2_parse_element_start(void *c, const char *elm, const cha
             if(siblingID == currentID) {
                 if(!fmi2_xml_scheme_info[currentID].multipleAllowed) {
                     jm_log_error(context->callbacks, module, 
-                        "[Line:%u] Multiple instances of XML element '%s' are not allowed, skipping",
+                        "[Line:%lu] Multiple instances of XML element '%s' are not allowed, skipping",
                         XML_GetCurrentLineNumber(context->parser), elm);
                     context->skipElementCnt = 1;
                     return;
@@ -449,7 +449,7 @@ static void XMLCALL fmi2_parse_element_start(void *c, const char *elm, const cha
 
                 if(lastSiblingIndex >= curSiblingIndex) {
                     jm_log_error(context->callbacks, module, 
-                        "[Line:%u] XML element '%s' cannot be placed after element '%s', skipping",
+                        "[Line:%lu] XML element '%s' cannot be placed after element '%s', skipping",
                         XML_GetCurrentLineNumber(context->parser), elm, fmi2_element_handle_map[siblingID].elementName);
                     context->skipElementCnt = 1;
                     return;
@@ -618,7 +618,7 @@ static void XMLCALL fmi2_parse_element_data(void* c, const XML_Char *s, int len)
         }
 
         if((i != len) && !context->has_produced_data_warning) {
-            jm_log_warning(context->callbacks, module, "[Line:%u] Skipping unexpected XML element data",
+            jm_log_warning(context->callbacks, module, "[Line:%lu] Skipping unexpected XML element data",
                     XML_GetCurrentLineNumber(context->parser));
             context->has_produced_data_warning = 1;
         }

--- a/src/XML/src/FMI2/fmi2_xml_parser.h
+++ b/src/XML/src/FMI2/fmi2_xml_parser.h
@@ -18,6 +18,7 @@
 
 #include <expat.h>
 
+#include <JM/jm_callbacks.h>
 #include <JM/jm_vector.h>
 #include <JM/jm_stack.h>
 #include <JM/jm_named_ptr.h>
@@ -297,8 +298,8 @@ int fmi2_xml_alloc_parse_buffer(fmi2_xml_parser_context_t *context, size_t items
 
 void fmi2_xml_free_parse_buffer(fmi2_xml_parser_context_t *context);
 
-void fmi2_xml_parse_fatal(fmi2_xml_parser_context_t *context, const char* fmt, ...);
-void fmi2_xml_parse_error(fmi2_xml_parser_context_t *context, const char* fmt, ...);
+void fmi2_xml_parse_fatal(fmi2_xml_parser_context_t *context, const char* fmt, ...) jm_printf_format(2);
+void fmi2_xml_parse_error(fmi2_xml_parser_context_t *context, const char* fmt, ...) jm_printf_format(2);
 
 int fmi2_xml_set_attr_string(fmi2_xml_parser_context_t *context, fmi2_xml_elm_enu_t elmID, fmi2_xml_attr_enu_t attrID, int required, jm_vector(char)* field);
 int fmi2_xml_set_attr_uint(fmi2_xml_parser_context_t *context, fmi2_xml_elm_enu_t elmID, fmi2_xml_attr_enu_t attrID, int required, unsigned int* field, unsigned int defaultVal);

--- a/src/XML/src/FMI2/fmi2_xml_variable.c
+++ b/src/XML/src/FMI2/fmi2_xml_variable.c
@@ -510,23 +510,23 @@ static void fmi2_log_error_if_start_required(
     fmi2_xml_variable_t *variable)
 {
     if (variable->causality == fmi2_causality_enu_input) {
-        jm_log_error(context->callbacks,
+        jm_log_error(context->callbacks, module,
                        "Error: variable %s: start value required for input variables",
                        variable->name);
     } else if (variable->causality == fmi2_causality_enu_parameter) {
-        jm_log_error(context->callbacks,
+        jm_log_error(context->callbacks, module,
                        "Error: variable %s: start value required for parameter variables",
                        variable->name);
     } else if (variable->variability == fmi2_variability_enu_constant) {
-        jm_log_error(context->callbacks,
+        jm_log_error(context->callbacks, module,
                        "Error: variable %s: start value required for variables with constant variability",
                        variable->name);
     } else if (variable->initial == fmi2_initial_enu_exact) {
-        jm_log_error(context->callbacks,
+        jm_log_error(context->callbacks, module,
                        "Error: variable %s: start value required for variables with initial == \"exact\"",
                        variable->name);
     } else if (variable->initial == fmi2_initial_enu_approx) {
-        jm_log_error(context->callbacks,
+        jm_log_error(context->callbacks, module,
                        "Error: variable %s: start value required for variables with initial == \"approx\"",
                        variable->name);
     }

--- a/src/XML/src/FMI3/fmi3_xml_model_structure.c
+++ b/src/XML/src/FMI3/fmi3_xml_model_structure.c
@@ -262,7 +262,7 @@ static int fmi3_xml_parse_dependencies(fmi3_xml_parser_context_t* context,
             }
             if (!ch) break;
             if (sscanf(cur, "%lld", &ind) != 1) {
-                fmi3_xml_parse_error(context, "XML element '%s': could not parse item %d, character '%c' in the list for attribute 'dependencies'",
+                fmi3_xml_parse_error(context, "XML element '%s': could not parse item %zu, character '%c' in the list for attribute 'dependencies'",
                     fmi3_xml_elmid_to_name(context, elmID), *numDepInd, ch);
                 return -1;
             }
@@ -330,7 +330,7 @@ static int fmi3_xml_parse_dependencies(fmi3_xml_parser_context_t* context,
                 cur+=8;
             }
             else {
-                fmi3_xml_parse_error(context, "XML element '%s': could not parse item %d in the list for attribute 'dependenciesKind'",
+                fmi3_xml_parse_error(context, "XML element '%s': could not parse item %zu in the list for attribute 'dependenciesKind'",
                     fmi3_xml_elmid_to_name(context, elmID), *numDepKind);
                 return -1;
             }
@@ -351,7 +351,7 @@ static int fmi3_xml_parse_dependencies(fmi3_xml_parser_context_t* context,
     if (listInd && listKind) {
         /* both lists are present - the number of items must match */
         if (*numDepInd != *numDepKind) {
-            fmi3_xml_parse_error(context, "XML element '%s': different number of items (%u and %u) in the lists for 'dependencies' and 'dependenciesKind'",
+            fmi3_xml_parse_error(context, "XML element '%s': different number of items (%zu and %zu) in the lists for 'dependencies' and 'dependenciesKind'",
                     fmi3_xml_elmid_to_name(context, elmID), *numDepInd, *numDepKind);
             return -1;
         }

--- a/src/XML/src/FMI3/fmi3_xml_parser.c
+++ b/src/XML/src/FMI3/fmi3_xml_parser.c
@@ -993,7 +993,7 @@ static void XMLCALL fmi3_parse_element_start(void *c, const char *elm, const cha
 
     if (context->skipElementCnt) {
         context->skipElementCnt++;
-        jm_log_warning(context->callbacks, module, "[Line:%u] Skipping nested XML element '%s'",
+        jm_log_warning(context->callbacks, module, "[Line:%lu] Skipping nested XML element '%s'",
             XML_GetCurrentLineNumber(context->parser), elm);
         return;
     }
@@ -1003,7 +1003,7 @@ static void XMLCALL fmi3_parse_element_start(void *c, const char *elm, const cha
     currentElMap = jm_vector_bsearch(fmi3_xml_element_handle_map_t)(context->elmMap, &keyEl, fmi3_xml_compare_elmName);
     if (!currentElMap) {
         /* not found error*/
-        jm_log_error(context->callbacks, module, "[Line:%u] Unknown element '%s' in XML, skipping",
+        jm_log_error(context->callbacks, module, "[Line:%lu] Unknown element '%s' in XML, skipping",
             XML_GetCurrentLineNumber(context->parser), elm);
         /* skipElementCnt:
          *  Instead of calling exit when we find a first 'Unknown' element, we set skipElementCnt to 1, and continue parsing.
@@ -1023,7 +1023,7 @@ static void XMLCALL fmi3_parse_element_start(void *c, const char *elm, const cha
 
         if (!fmi3_xml_is_valid_parent(context, currentID, parentID)) {
                 jm_log_error(context->callbacks, module,
-                    "[Line:%u] XML element '%s' cannot be placed inside '%s', skipping",
+                    "[Line:%lu] XML element '%s' cannot be placed inside '%s', skipping",
                     XML_GetCurrentLineNumber(context->parser), elm, fmi3_xml_elmid_to_name(context, parentID));
                 context->skipElementCnt = 1;
                 return;
@@ -1032,7 +1032,7 @@ static void XMLCALL fmi3_parse_element_start(void *c, const char *elm, const cha
             if (fmi3_xml_are_same_type(context, currentID, siblingID)) {
                 if (!(fmi3_xml_get_scheme_info(context, currentID).multipleAllowed && fmi3_xml_get_scheme_info(context, siblingID).multipleAllowed)) {
                     jm_log_error(context->callbacks, module,
-                        "[Line:%u] Multiple instances of XML element '%s' are not allowed, skipping",
+                        "[Line:%lu] Multiple instances of XML element '%s' are not allowed, skipping",
                         XML_GetCurrentLineNumber(context->parser), elm);
                     context->skipElementCnt = 1;
                     return;
@@ -1043,7 +1043,7 @@ static void XMLCALL fmi3_parse_element_start(void *c, const char *elm, const cha
 
                 if (lastSiblingIndex >= curSiblingIndex) {
                     jm_log_error(context->callbacks, module,
-                        "[Line:%u] XML element '%s' cannot be placed after element '%s', skipping",
+                        "[Line:%lu] XML element '%s' cannot be placed after element '%s', skipping",
                         XML_GetCurrentLineNumber(context->parser), elm, fmi3_xml_elmid_to_name(context, siblingID));
                     context->skipElementCnt = 1;
                     return;
@@ -1232,7 +1232,7 @@ static void XMLCALL fmi3_parse_element_data(void* c, const XML_Char *s, int len)
         }
 
         if ((i != len) && !context->has_produced_data_warning) {
-            jm_log_warning(context->callbacks, module, "[Line:%u] Skipping unexpected XML element data",
+            jm_log_warning(context->callbacks, module, "[Line:%lu] Skipping unexpected XML element data",
                     XML_GetCurrentLineNumber(context->parser));
             context->has_produced_data_warning = 1;
         }

--- a/src/XML/src/FMI3/fmi3_xml_parser_util.c
+++ b/src/XML/src/FMI3/fmi3_xml_parser_util.c
@@ -30,7 +30,7 @@ void fmi3_xml_parse_error(fmi3_xml_parser_context_t* context, const char* fmt, .
     va_list args;
     va_start (args, fmt);
     if (context->parser)
-        jm_log_info(context->callbacks, module, "[Line:%u] Detected during parsing:", XML_GetCurrentLineNumber(context->parser));
+        jm_log_info(context->callbacks, module, "[Line:%lu] Detected during parsing:", XML_GetCurrentLineNumber(context->parser));
     jm_log_error_v(context->callbacks, module, fmt, args);
     va_end (args);
 }
@@ -39,7 +39,7 @@ void fmi3_xml_parse_warning(fmi3_xml_parser_context_t* context, const char* fmt,
     va_list args;
     va_start (args, fmt);
     if (context->parser)
-        jm_log_info(context->callbacks, module, "[Line:%u] Detected during parsing:", XML_GetCurrentLineNumber(context->parser));
+        jm_log_info(context->callbacks, module, "[Line:%lu] Detected during parsing:", XML_GetCurrentLineNumber(context->parser));
     jm_log_warning_v(context->callbacks, module, fmt, args);
     va_end (args);
 }

--- a/src/XML/src/FMI3/fmi3_xml_parser_util.h
+++ b/src/XML/src/FMI3/fmi3_xml_parser_util.h
@@ -17,14 +17,15 @@
 #define FMI3_XML_XMLPARSER_UTIL_H
 
 #include "fmi3_xml_parser_context_impl.h"
+#include <JM/jm_callbacks.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void fmi3_xml_parse_fatal  (fmi3_xml_parser_context_t* context, const char* fmt, ...);
-void fmi3_xml_parse_error  (fmi3_xml_parser_context_t* context, const char* fmt, ...);
-void fmi3_xml_parse_warning(fmi3_xml_parser_context_t* context, const char* fmt, ...);
+void fmi3_xml_parse_fatal  (fmi3_xml_parser_context_t* context, const char* fmt, ...) jm_printf_format(2);
+void fmi3_xml_parse_error  (fmi3_xml_parser_context_t* context, const char* fmt, ...) jm_printf_format(2);
+void fmi3_xml_parse_warning(fmi3_xml_parser_context_t* context, const char* fmt, ...) jm_printf_format(2);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Add a macro to make gcc and clang check the format strings of all printf-like functions. Fix any errors found by gcc.

Note: the new macros can only attach to function declarations. Where there was no previous declaration (some static functions), a new function declaration was added directly before the definition.