### PR TITLE
Added clarifications that get_enum_item_* functions are index 1 based

### DIFF
--- a/src/Import/include/FMI1/fmi1_import_type.h
+++ b/src/Import/include/FMI1/fmi1_import_type.h
@@ -140,9 +140,9 @@ FMILIB_EXPORT unsigned int fmi1_import_get_enum_type_max(fmi1_import_enumeration
 /** \brief Get the number of elements in the enum */
 FMILIB_EXPORT unsigned int  fmi1_import_get_enum_type_size(fmi1_import_enumeration_typedef_t*);
 
-/** \brief Get an enumeration item name by index */
+/** \brief Get an enumeration item name by index (1-based) */
 FMILIB_EXPORT const char* fmi1_import_get_enum_type_item_name(fmi1_import_enumeration_typedef_t*, unsigned int  item);
-/** \brief Get an enumeration item description by index */
+/** \brief Get an enumeration item description by index (1-based) */
 FMILIB_EXPORT const char* fmi1_import_get_enum_type_item_description(fmi1_import_enumeration_typedef_t*, unsigned int  item);
 
 /**

--- a/src/Import/include/FMI2/fmi2_import_type.h
+++ b/src/Import/include/FMI2/fmi2_import_type.h
@@ -143,13 +143,13 @@ FMILIB_EXPORT unsigned int fmi2_import_get_enum_type_max(fmi2_import_enumeration
 /** \brief Get the number of elements in the enum */
 FMILIB_EXPORT unsigned int  fmi2_import_get_enum_type_size(fmi2_import_enumeration_typedef_t*);
 
-/** \brief Get an enumeration item name by index */
+/** \brief Get an enumeration item name by index (1-based) */
 FMILIB_EXPORT const char* fmi2_import_get_enum_type_item_name(fmi2_import_enumeration_typedef_t*, unsigned int  item);
 
-/** \brief Get an enumeration item value by index */
+/** \brief Get an enumeration item value by index (1-based) */
 FMILIB_EXPORT int fmi2_import_get_enum_type_item_value(fmi2_import_enumeration_typedef_t*, unsigned int  item);
 
-/** \brief Get an enumeration item description by index */
+/** \brief Get an enumeration item description by index (1-based) */
 FMILIB_EXPORT const char* fmi2_import_get_enum_type_item_description(fmi2_import_enumeration_typedef_t*, unsigned int  item);
 
 /** \brief Get an enumeration item name for the given value */

--- a/src/Import/include/FMI3/fmi3_import_type.h
+++ b/src/Import/include/FMI3/fmi3_import_type.h
@@ -263,13 +263,13 @@ FMILIB_EXPORT unsigned int fmi3_import_get_enum_type_max(fmi3_import_enumeration
 /** \brief Get the number of elements in the enum */
 FMILIB_EXPORT size_t fmi3_import_get_enum_type_size(fmi3_import_enumeration_typedef_t* td);
 
-/** \brief Get an enumeration item name by index */
+/** \brief Get an enumeration item name by index (1-based) */
 FMILIB_EXPORT const char* fmi3_import_get_enum_type_item_name(fmi3_import_enumeration_typedef_t* td, size_t item);
 
-/** \brief Get an enumeration item value by index */
+/** \brief Get an enumeration item value by index (1-based) */
 FMILIB_EXPORT int fmi3_import_get_enum_type_item_value(fmi3_import_enumeration_typedef_t* td, size_t item);
 
-/** \brief Get an enumeration item description by index */
+/** \brief Get an enumeration item description by index (1-based) */
 FMILIB_EXPORT const char* fmi3_import_get_enum_type_item_description(fmi3_import_enumeration_typedef_t* td, size_t item);
 
 /** \brief Get an enumeration item name for the given value */

--- a/src/XML/src/FMI3/fmi3_xml_type.c
+++ b/src/XML/src/FMI3/fmi3_xml_type.c
@@ -348,14 +348,14 @@ unsigned int fmi3_xml_get_enum_type_size(fmi3_xml_enumeration_typedef_t* t) {
 }
 
 const char* fmi3_xml_get_enum_type_item_name(fmi3_xml_enumeration_typedef_t* t, unsigned int  item) {
-    /* TODO: FUTURE; make this 0-based */
+    /* TODO: FMI4; make this 0-based */
     fmi3_xml_enum_typedef_props_t* props = fmi3_xml_get_enum_typedef_props(t);
     if((item == 0) || (item > fmi3_xml_get_enum_type_size(t) )) return  0;
     return jm_vector_get_item(jm_named_ptr)(&props->enumItems,item-1).name;
 }
 
 int fmi3_xml_get_enum_type_item_value(fmi3_xml_enumeration_typedef_t* t, unsigned int  item) {
-    /* TODO: FUTURE; make this 0-based */
+    /* TODO: FMI4; make this 0-based */
     fmi3_xml_enum_typedef_props_t* props = fmi3_xml_get_enum_typedef_props(t);
     fmi3_xml_enum_type_item_t* eitem;
     if((item == 0) || (item > fmi3_xml_get_enum_type_size(t) )) return  0;
@@ -375,7 +375,7 @@ const char* fmi3_xml_get_enum_type_value_name(fmi3_xml_enumeration_typedef_t* t,
 }
 
 const char* fmi3_xml_get_enum_type_item_description(fmi3_xml_enumeration_typedef_t* t, unsigned int  item){
-    /* TODO: FUTURE; make this 0-based */
+    /* TODO: FMI4; make this 0-based */
     fmi3_xml_enum_typedef_props_t* props = fmi3_xml_get_enum_typedef_props(t);
     fmi3_xml_enum_type_item_t* e;
     if(item > fmi3_xml_get_enum_type_size(t) ) return  0;

--- a/src/XML/src/FMI3/fmi3_xml_type.c
+++ b/src/XML/src/FMI3/fmi3_xml_type.c
@@ -348,12 +348,14 @@ unsigned int fmi3_xml_get_enum_type_size(fmi3_xml_enumeration_typedef_t* t) {
 }
 
 const char* fmi3_xml_get_enum_type_item_name(fmi3_xml_enumeration_typedef_t* t, unsigned int  item) {
+    /* TODO: FUTURE; make this 0-based */
     fmi3_xml_enum_typedef_props_t* props = fmi3_xml_get_enum_typedef_props(t);
     if((item == 0) || (item > fmi3_xml_get_enum_type_size(t) )) return  0;
     return jm_vector_get_item(jm_named_ptr)(&props->enumItems,item-1).name;
 }
 
 int fmi3_xml_get_enum_type_item_value(fmi3_xml_enumeration_typedef_t* t, unsigned int  item) {
+    /* TODO: FUTURE; make this 0-based */
     fmi3_xml_enum_typedef_props_t* props = fmi3_xml_get_enum_typedef_props(t);
     fmi3_xml_enum_type_item_t* eitem;
     if((item == 0) || (item > fmi3_xml_get_enum_type_size(t) )) return  0;
@@ -373,6 +375,7 @@ const char* fmi3_xml_get_enum_type_value_name(fmi3_xml_enumeration_typedef_t* t,
 }
 
 const char* fmi3_xml_get_enum_type_item_description(fmi3_xml_enumeration_typedef_t* t, unsigned int  item){
+    /* TODO: FUTURE; make this 0-based */
     fmi3_xml_enum_typedef_props_t* props = fmi3_xml_get_enum_typedef_props(t);
     fmi3_xml_enum_type_item_t* e;
     if(item > fmi3_xml_get_enum_type_size(t) ) return  0;


### PR DESCRIPTION
For https://github.com/modelon-community/fmi-library/issues/197