### PR TITLE
FMI parsing: accept patch-level FMI 3.0.x versions

### DIFF
--- a/src/XML/src/FMI/fmi_xml_context.c
+++ b/src/XML/src/FMI/fmi_xml_context.c
@@ -105,7 +105,7 @@ void XMLCALL fmi_xml_parse_element_start(void *c, const char *elm, const char **
         XML_StopParser(context->parser,0);
         return;
     }
-    else if( strcmp(fmiVersion, "3.0") == 0 ) {
+    else if( strncmp(fmiVersion, "3.0", 3) == 0 && (fmiVersion[3] == '\0' || fmiVersion[3] == '.') ) {
         jm_log_verbose(context->callbacks, MODULE, "XML specifies FMI 3.0");
         context->fmi_version = fmi_version_3_0_enu;
         XML_StopParser(context->parser,0);


### PR DESCRIPTION
Replace exact strcmp("3.0") with a prefix check that also accepts "3.0.1", "3.0.x", etc. as FMI 3.0, while rejecting "3.1", "3.2".

Closes #217